### PR TITLE
[Auth] Spotifyのアクセストークンを保存する処理を追加

### DIFF
--- a/domain/repository/auth.go
+++ b/domain/repository/auth.go
@@ -1,10 +1,15 @@
 package repository
 
-import "github.com/camphor-/relaym-server/domain/entity"
+import (
+	"github.com/camphor-/relaym-server/domain/entity"
+	"golang.org/x/oauth2"
+)
 
 // Auth は認証・認可に関するの永続化を担当するリポジトリです。
 type Auth interface {
-	Store(authState *entity.AuthState) error
+	StoreORUpdateToken(spotifyUserID string, token *oauth2.Token) error
+	GetTokenBySpotifyUserID(spotifyUserID string) (*oauth2.Token, error)
+	StoreState(authState *entity.AuthState) error
 	FindStateByState(state string) (*entity.AuthState, error)
 	Delete(state string) error
 }

--- a/domain/repository/auth.go
+++ b/domain/repository/auth.go
@@ -5,7 +5,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-// Auth は認証・認可に関するの永続化を担当するリポジトリです。
+// Auth は認証・認可に関する永続化を担当するリポジトリです。
 type Auth interface {
 	StoreORUpdateToken(spotifyUserID string, token *oauth2.Token) error
 	GetTokenBySpotifyUserID(spotifyUserID string) (*oauth2.Token, error)

--- a/mysql/schemas/relaym/spotify_auth.sql
+++ b/mysql/schemas/relaym/spotify_auth.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `spotify_auth` (
+  `spotify_user_id` varchar(255) COLLATE utf8mb4_bin NOT NULL COMMENT 'ユーザID',
+  `access_token` varchar(255) COLLATE utf8mb4_bin NOT NULL COMMENT 'Spotify OAuth2のアクセストークン',
+  `refresh_token` varchar(255) COLLATE utf8mb4_bin NOT NULL COMMENT 'Spotify OAuth2のリフレッシュトークン',
+  `expiry` datetime NOT NULL COMMENT 'アクセストークンの有効期限',
+  PRIMARY KEY (`spotify_user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;

--- a/usecase/auth.go
+++ b/usecase/auth.go
@@ -51,7 +51,7 @@ func (u *AuthUseCase) Authorization(state, code string) (string, error) {
 	// TODO : SpotifyUserIDを取得する
 	spotifyUserID := "spotifyUserID"
 	if err := u.repo.StoreORUpdateToken(spotifyUserID, token); err != nil {
-		return "", fmt.Errorf("store or update oauth token though repo spotifyUserID=%s: %w", spotifyUserID, err)
+		return "", fmt.Errorf("store or update oauth token through repo spotifyUserID=%s: %w", spotifyUserID, err)
 	}
 	fmt.Printf("%#v\n", token)
 

--- a/usecase/auth.go
+++ b/usecase/auth.go
@@ -30,7 +30,7 @@ func (u *AuthUseCase) GetAuthURL(redirectURL string) (string, error) {
 		State:       state,
 		RedirectURL: redirectURL,
 	}
-	if err := u.repo.Store(st); err != nil {
+	if err := u.repo.StoreState(st); err != nil {
 		return "", fmt.Errorf("store state for authorization: %w", err)
 	}
 	return u.authCli.GetAuthURL(state), nil
@@ -48,7 +48,11 @@ func (u *AuthUseCase) Authorization(state, code string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("exchange and get oauth2 token: %w", err)
 	}
-	// TODO : 手に入れたアクセストークンをDBに保存する
+	// TODO : SpotifyUserIDを取得する
+	spotifyUserID := "spotifyUserID"
+	if err := u.repo.StoreORUpdateToken(spotifyUserID, token); err != nil {
+		return "", fmt.Errorf("store or update oauth token though repo spotifyUserID=%s: %w", spotifyUserID, err)
+	}
 	fmt.Printf("%#v\n", token)
 
 	// Stateを削除するのが失敗してもログインは成功しているので、エラーを返さない

--- a/web/handler/auth_test.go
+++ b/web/handler/auth_test.go
@@ -131,7 +131,15 @@ func (f fakeSpotifyAuth) Exchange(code string) (*oauth2.Token, error) {
 
 type fakeAuthRepository struct{}
 
-func (f fakeAuthRepository) Store(state *entity.AuthState) error {
+func (f fakeAuthRepository) StoreORUpdateToken(spotifyUserID string, token *oauth2.Token) error {
+	panic("implement me")
+}
+
+func (f fakeAuthRepository) GetTokenBySpotifyUserID(spotifyUserID string) (*oauth2.Token, error) {
+	panic("implement me")
+}
+
+func (f fakeAuthRepository) StoreState(state *entity.AuthState) error {
 	return nil
 }
 

--- a/web/handler/auth_test.go
+++ b/web/handler/auth_test.go
@@ -132,11 +132,16 @@ func (f fakeSpotifyAuth) Exchange(code string) (*oauth2.Token, error) {
 type fakeAuthRepository struct{}
 
 func (f fakeAuthRepository) StoreORUpdateToken(spotifyUserID string, token *oauth2.Token) error {
-	panic("implement me")
+	return nil
 }
 
 func (f fakeAuthRepository) GetTokenBySpotifyUserID(spotifyUserID string) (*oauth2.Token, error) {
-	panic("implement me")
+	return &oauth2.Token{
+		AccessToken:  "access_token",
+		TokenType:    "Bearer",
+		RefreshToken: "refresh_token",
+		Expiry:       time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+	}, nil
 }
 
 func (f fakeAuthRepository) StoreState(state *entity.AuthState) error {

--- a/web/handler/user_test.go
+++ b/web/handler/user_test.go
@@ -39,7 +39,6 @@ func TestUserHandler_GetMe(t *testing.T) {
 			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
 			rec := httptest.NewRecorder()
 			c := e.NewContext(req, rec)
-
 			// TODO モックは自動生成したい
 			uc := usecase.NewUserUseCase(&fakeUserRepository{})
 			h := &UserHandler{userUC: uc}


### PR DESCRIPTION
## Related Issue

#11 

## What

- Spotifyのアクセストークンを保存する処理を追加

## Memo
<!-- レビュワーに伝えたいことがあれば -->
- APIコール時にアクセストークンを取得する処理は別PRにします
- spotifyUserIDを取得する処理も別PRにします