### PR TITLE
曲の一時停止用のAPIを実装

### DIFF
--- a/database/session.go
+++ b/database/session.go
@@ -86,12 +86,8 @@ func (r *SessionRepository) Update(session *entity.Session) error {
 		StateType: session.StateType.String(),
 	}
 
-	updateNum, err := r.dbMap.Update(dto)
-	if err != nil {
+	if _, err := r.dbMap.Update(dto); err != nil {
 		return fmt.Errorf("update session: %w", err)
-	}
-	if updateNum == 0 {
-		return fmt.Errorf("update session: %w", entity.ErrSessionNotFound)
 	}
 	return nil
 }

--- a/database/session_test.go
+++ b/database/session_test.go
@@ -174,7 +174,14 @@ func TestSessionRepository_Update(t *testing.T) {
 		QueueHead: 0,
 		StateType: "PAUSE",
 	}
-	if err := dbMap.Insert(user, session); err != nil {
+	sameFieldSession := &sessionDTO{
+		ID:        "same_field_session_id",
+		Name:      "same_field_session_name",
+		CreatorID: "existing_user",
+		QueueHead: 0,
+		StateType: "PAUSE",
+	}
+	if err := dbMap.Insert(user, session, sameFieldSession); err != nil {
 		t.Fatal(err)
 	}
 
@@ -196,16 +203,16 @@ func TestSessionRepository_Update(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "存在しないセッションはエラーになる",
+			name: "フィールドの値が全てDBの値を一致するセッションで更新してもエラーにならない",
 			session: &entity.Session{
-				ID:          "not_found_id",
-				Name:        "not_found_id_names",
+				ID:          "same_field_session_id",
+				Name:        "same_field_session_name",
 				CreatorID:   "existing_user",
-				QueueHead:   1,
-				StateType:   entity.Play,
+				QueueHead:   0,
+				StateType:   entity.Pause,
 				QueueTracks: []*entity.QueueTrack{},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {

--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -21,6 +21,15 @@ func (s *Session) MoveToPlay() error {
 	return fmt.Errorf("state type from %s to Play: %w", s.StateType, ErrChangeSessionStateNotPermit)
 }
 
+// MoveToPause はセッションのStateTypeをPauseに状態遷移します。
+func (s *Session) MoveToPause() error {
+	if s.StateType == Play || s.StateType == Pause {
+		s.StateType = Pause
+		return nil
+	}
+	return fmt.Errorf("state type from %s to Play: %w", s.StateType, ErrChangeSessionStateNotPermit)
+}
+
 type StateType string
 
 const (

--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -25,7 +25,7 @@ func (s *Session) MoveToPause() error {
 		s.StateType = Pause
 		return nil
 	}
-	return fmt.Errorf("state type from %s to Play: %w", s.StateType, ErrChangeSessionStateNotPermit)
+	return fmt.Errorf("state type from %s to Pause: %w", s.StateType, ErrChangeSessionStateNotPermit)
 }
 
 type StateType string

--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -14,11 +14,9 @@ type Session struct {
 
 // MoveToPlay はセッションのStateTypeをPlayに状態遷移します。
 func (s *Session) MoveToPlay() error {
-	if s.StateType == Pause || s.StateType == Stop {
-		s.StateType = Play
-		return nil
-	}
-	return fmt.Errorf("state type from %s to Play: %w", s.StateType, ErrChangeSessionStateNotPermit)
+	s.StateType = Play
+	return nil
+
 }
 
 // MoveToPause はセッションのStateTypeをPauseに状態遷移します。

--- a/domain/entity/session_test.go
+++ b/domain/entity/session_test.go
@@ -109,3 +109,40 @@ func TestSession_MoveToPause(t *testing.T) {
 		})
 	}
 }
+
+func TestSession_MoveToPlay(t *testing.T) {
+	tests := []struct {
+		name    string
+		session *Session
+		wantErr bool
+	}{
+		{
+			name: "Play",
+			session: &Session{
+				StateType: Play,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Pause",
+			session: &Session{
+				StateType: Pause,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Stop",
+			session: &Session{
+				StateType: Stop,
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.session.MoveToPlay(); (err != nil) != tt.wantErr {
+				t.Errorf("MoveToPlay() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/domain/entity/session_test.go
+++ b/domain/entity/session_test.go
@@ -72,3 +72,40 @@ func TestStateType_String(t *testing.T) {
 		})
 	}
 }
+
+func TestSession_MoveToPause(t *testing.T) {
+	tests := []struct {
+		name    string
+		session *Session
+		wantErr bool
+	}{
+		{
+			name: "Play",
+			session: &Session{
+				StateType: Play,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Pause",
+			session: &Session{
+				StateType: Pause,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Stop",
+			session: &Session{
+				StateType: Stop,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := tt.session.MoveToPause(); (err != nil) != tt.wantErr {
+				t.Errorf("MoveToPause() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -100,7 +100,7 @@ func (s *SessionUseCase) play(ctx context.Context, sessionID string) error {
 
 // Pause はセッションのstateをPLAY→PAUSEに変更して曲の再生を一時停止します。
 func (s *SessionUseCase) pause(ctx context.Context, sessionID string) error {
-	sess, err := s.repo.FindByID(sessionID)
+	sess, err := s.sessionRepo.FindByID(sessionID)
 	if err != nil {
 		return fmt.Errorf("find session id=%s: %w", sessionID, err)
 	}
@@ -116,7 +116,7 @@ func (s *SessionUseCase) pause(ctx context.Context, sessionID string) error {
 		return fmt.Errorf("move to pause id=%s: %w", sessionID, err)
 	}
 
-	if err := s.repo.Update(sess); err != nil {
+	if err := s.sessionRepo.Update(sess); err != nil {
 		return fmt.Errorf("update session id=%s: %w", sessionID, err)
 	}
 

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -2,6 +2,7 @@ package usecase
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -78,14 +79,26 @@ func (s *SessionUseCase) play(ctx context.Context, sessionID string) error {
 
 // Pause はセッションのstateをPLAY→PAUSEに変更して曲の再生を一時停止します。
 func (s *SessionUseCase) pause(ctx context.Context, sessionID string) error {
-	// TODO : セッションを取得
-	// sess ,err := repo.GetByID(sessionID)
+	sess, err := s.repo.FindByID(sessionID)
+	if err != nil {
+		return fmt.Errorf("find session id=%s: %w", sessionID, err)
+	}
+
+	// TODO : デバイスIDをどっかから読み込む
+	if err := s.playerCli.Pause(ctx, ""); err != nil && !errors.Is(err, entity.ErrActiveDeviceNotFound) {
+		return fmt.Errorf("call pause api: %w", err)
+	}
 
 	s.tm.StopTimer(sessionID)
 
-	// TODO : セッションのステートを書き換え
-	// err := sess.MoveToPause()
-	// err := repo.Store(sess)
+	if err := sess.MoveToPause(); err != nil {
+		return fmt.Errorf("move to pause id=%s: %w", sessionID, err)
+	}
+
+	if err := s.repo.Update(sess); err != nil {
+		return fmt.Errorf("update session id=%s: %w", sessionID, err)
+	}
+
 	return nil
 }
 

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -115,12 +115,13 @@ func TestSessionHandler_Playback(t *testing.T) {
 			wantCode: http.StatusAccepted,
 		},
 		{
-			name:                "PAUSEで指定されたidのセッションが存在しないとき404",
-			sessionID:           "notFoundSessionID",
-			body:                `{"state": "PAUSE"}`,
-			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {},
-			prepareMockPusherFn: func(m *mock_event.MockPusher) {},
-			prepareMockRepoFn: func(m *mock_repository.MockSession) {
+			name:                  "PAUSEで指定されたidのセッションが存在しないとき404",
+			sessionID:             "notFoundSessionID",
+			body:                  `{"state": "PAUSE"}`,
+			prepareMockPlayerFn:   func(m *mock_spotify.MockPlayer) {},
+			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID("notFoundSessionID").Return(nil, entity.ErrSessionNotFound)
 			},
 			wantErr:  true,
@@ -133,8 +134,9 @@ func TestSessionHandler_Playback(t *testing.T) {
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
 				m.EXPECT().Pause(gomock.Any(), "").Return(entity.ErrActiveDeviceNotFound)
 			},
-			prepareMockPusherFn: func(m *mock_event.MockPusher) {},
-			prepareMockRepoFn: func(m *mock_repository.MockSession) {
+			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
 					ID:          "sessionID",
 					Name:        "session_name",
@@ -164,7 +166,8 @@ func TestSessionHandler_Playback(t *testing.T) {
 			},
 			prepareMockPusherFn: func(m *mock_event.MockPusher) {
 			},
-			prepareMockRepoFn: func(m *mock_repository.MockSession) {
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
 					ID:          "sessionID",
 					Name:        "session_name",


### PR DESCRIPTION
## Related Issue

close #18 

## What

- 曲の一時停止用のAPIを実装
-  冪等性担保のために Play→Play、 Pause→Pauseの状態遷移はエラーにしない
- フィールドの値が全てDBの値を一致するセッションで更新した際にエラーになるバグがあったので修正

## Memo
<!-- レビュワーに伝えたいことがあれば -->