### PR TITLE
Queueに曲を追加するAPIを生やす

### DIFF
--- a/database/session.go
+++ b/database/session.go
@@ -59,6 +59,7 @@ func (r *SessionRepository) FindByID(id string) (*entity.Session, error) {
 	}, nil
 }
 
+// StoreSession はSessionをDBに挿入します。
 func (r *SessionRepository) StoreSession(session *entity.Session) error {
 	dto := &sessionDTO{
 		ID:        session.ID,
@@ -95,6 +96,7 @@ func (r *SessionRepository) Update(session *entity.Session) error {
 	return nil
 }
 
+// StoreQueueTrack はQueueTrackをDBに挿入します。
 func (r *SessionRepository) StoreQueueTrack(queueTrack *entity.QueueTrackToStore) error {
 	if _, err := r.dbMap.Exec("INSERT INTO queue_tracks(`index`, uri, session_id) SELECT COALESCE(MAX('index'),-1)+1, ?, ? from queue_tracks as qt WHERE session_id = ?;", queueTrack.URI, queueTrack.SessionID, queueTrack.SessionID); err != nil {
 		return fmt.Errorf("insert queue_tracks: %w", err)

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -83,7 +83,9 @@ func (c *Client) Pause(ctx context.Context, deviceID string) error {
 // APIが非同期で処理がされるため、リクエストが返ってきても曲の追加が完了しているとは限りません。
 // 設定が反映されたか確認するには CurrentlyPlaying() を叩く必要があります。
 // プレミアム会員必須
-func (c *Client) AddToQueue(ctx context.Context, trackID string, deviceID string) error {
+func (c *Client) AddToQueue(ctx context.Context, trackURI string, deviceID string) error {
+	trackID := strings.Replace(trackURI, "spotify:track", "", 1)
+
 	token, ok := service.GetTokenFromContext(ctx)
 	if !ok {
 		return errors.New("token not found")

--- a/spotify/player_test.go
+++ b/spotify/player_test.go
@@ -128,7 +128,7 @@ func TestClient_AddToQueue(t *testing.T) {
 	}{
 		{
 			name:    "曲をqueueに追加できる",
-			trackID: "49BRCNV7E94s7Q2FUhhT3w", // uriではなくidなので"spotify:track:"はいらない
+			trackID: "spotify:track:49BRCNV7E94s7Q2FUhhT3w",
 			wantErr: false,
 		},
 	}

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -39,7 +39,7 @@ func NewSessionUseCase(sessionRepo repository.Session, userRepo repository.User,
 func (s *SessionUseCase) AddQueueTrack(ctx context.Context, sessionID string, trackURI string) error {
 	session, err := s.sessionRepo.FindByID(sessionID)
 	if err != nil {
-		fmt.Errorf("FindByID sessionID=%s: %w", sessionID, err)
+		return fmt.Errorf("FindByID sessionID=%s: %w", sessionID, err)
 	}
 
 	err = s.sessionRepo.StoreQueueTrack(&entity.QueueTrackToStore{
@@ -47,13 +47,15 @@ func (s *SessionUseCase) AddQueueTrack(ctx context.Context, sessionID string, tr
 		SessionID: sessionID,
 	})
 	if err != nil {
-		fmt.Errorf("StoreQueueTrack URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
+		return fmt.Errorf("StoreQueueTrack URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
 	}
 
 	err = s.playerCli.AddToQueue(ctx, trackURI, session.DeviceID)
 	if err != nil {
-		fmt.Errorf("AddToQueue URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
+		return fmt.Errorf("AddToQueue URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
 	}
+
+	return nil
 }
 
 // CreateSession は与えられたセッション名のセッションを作成します。

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -35,6 +35,24 @@ func NewSessionUseCase(sessionRepo repository.Session, userRepo repository.User,
 	}
 }
 
+// AddQueueTrack はセッションのqueueにTrackを追加します。
+func (s *SessionUseCase) AddQueueTrack(ctx context.Context, sessionID string, trackURI string) error {
+	session, err := s.sessionRepo.FindByID(sessionID)
+	if err != nil {
+		fmt.Errorf("FindByID sessionID=%s: %w", sessionID, err)
+	}
+
+	err = s.sessionRepo.StoreQueueTrack(&entity.QueueTrackToStore{
+		URI:       trackURI,
+		SessionID: sessionID,
+	})
+	if err != nil {
+		fmt.Errorf("StoreQueueTrack URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
+	}
+
+	err = s.playerCli.AddToQueue(ctx, trackURI, session.)
+}
+
 // CreateSession は与えられたセッション名のセッションを作成します。
 func (s *SessionUseCase) CreateSession(sessionName string, creatorID string) (*entity.SessionWithUser, error) {
 	creator, err := s.userRepo.FindByID(creatorID)

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -50,7 +50,10 @@ func (s *SessionUseCase) AddQueueTrack(ctx context.Context, sessionID string, tr
 		fmt.Errorf("StoreQueueTrack URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
 	}
 
-	err = s.playerCli.AddToQueue(ctx, trackURI, session.)
+	err = s.playerCli.AddToQueue(ctx, trackURI, session.DeviceID)
+	if err != nil {
+		fmt.Errorf("AddToQueue URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
+	}
 }
 
 // CreateSession は与えられたセッション名のセッションを作成します。

--- a/web/handler/session.go
+++ b/web/handler/session.go
@@ -68,6 +68,23 @@ func (h *SessionHandler) toSessionRes(session *entity.SessionWithUser) *sessionR
 	}
 }
 
+// AddQueue は POST /sessions/:id/queue に対応するハンドラーです。
+func (h *SessionHandler) AddQueue(c echo.Context) error {
+	type reqJSON struct {
+		State string `json:"uri"`
+	}
+	req := new(reqJSON)
+	if err := c.Bind(req); err != nil {
+		c.Logger().Debugf("bind: %v", err)
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid track id")
+	}
+
+	ctx := c.Request().Context()
+	sessionID := c.Param("id")
+
+	return c.NoContent(http.StatusAccepted)
+}
+
 // Playback は PUT /sessions/:id/playback に対応するハンドラーです。
 func (h *SessionHandler) Playback(c echo.Context) error {
 	type reqJSON struct {

--- a/web/handler/session.go
+++ b/web/handler/session.go
@@ -82,6 +82,14 @@ func (h *SessionHandler) AddQueue(c echo.Context) error {
 	ctx := c.Request().Context()
 	sessionID := c.Param("id")
 
+	if err := h.uc.AddQueueTrack(ctx, sessionID, req.State); err != nil {
+		if errors.Is(err, entity.ErrSessionNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, entity.ErrSessionNotFound.Error())
+		}
+		c.Logger().Errorf("add queue track: %v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
 	return c.NoContent(http.StatusAccepted)
 }
 

--- a/web/handler/session.go
+++ b/web/handler/session.go
@@ -71,7 +71,7 @@ func (h *SessionHandler) toSessionRes(session *entity.SessionWithUser) *sessionR
 // AddQueue は POST /sessions/:id/queue に対応するハンドラーです。
 func (h *SessionHandler) AddQueue(c echo.Context) error {
 	type reqJSON struct {
-		State string `json:"uri"`
+		URI string `json:"uri"`
 	}
 	req := new(reqJSON)
 	if err := c.Bind(req); err != nil {
@@ -79,10 +79,14 @@ func (h *SessionHandler) AddQueue(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid track id")
 	}
 
+	if req.URI == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "invalid track id")
+	}
+
 	ctx := c.Request().Context()
 	sessionID := c.Param("id")
 
-	if err := h.uc.AddQueueTrack(ctx, sessionID, req.State); err != nil {
+	if err := h.uc.AddQueueTrack(ctx, sessionID, req.URI); err != nil {
 		if errors.Is(err, entity.ErrSessionNotFound) {
 			return echo.NewHTTPError(http.StatusNotFound, entity.ErrSessionNotFound.Error())
 		}
@@ -90,7 +94,7 @@ func (h *SessionHandler) AddQueue(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
-	return c.NoContent(http.StatusAccepted)
+	return c.NoContent(http.StatusNoContent)
 }
 
 // Playback は PUT /sessions/:id/playback に対応するハンドラーです。

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -477,7 +477,7 @@ func TestSessionHandler_AddQueue(t *testing.T) {
 		QueueHead: 0,
 		QueueTracks: []*entity.QueueTrack{{
 			Index:     0,
-			URI:       "existed_session_uri",
+			URI:       "spotify:track:existed_session_uri",
 			SessionID: "sessionID",
 		},
 		},
@@ -499,14 +499,14 @@ func TestSessionHandler_AddQueue(t *testing.T) {
 			sessionID: "sessionID",
 			body:      `{"uri": "valid_uri"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
-				m.EXPECT().AddToQueue(gomock.Any(), "valid_uri", "sessionDeviceID").Return(nil)
+				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:valid_uri", "sessionDeviceID").Return(nil)
 			},
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID("sessionID").Return(session, nil)
 				m.EXPECT().StoreQueueTrack(&entity.QueueTrackToStore{
-					URI:       "valid_uri",
+					URI:       "spotify:track:valid_uri",
 					SessionID: "sessionID",
 				}).Return(nil)
 			},

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -466,3 +466,114 @@ func TestSessionHandler_PostSession(t *testing.T) {
 		})
 	}
 }
+
+func TestSessionHandler_AddQueue(t *testing.T) {
+	session := &entity.Session{
+		ID:        "sessionID",
+		Name:      "sessionName",
+		CreatorID: "sessionCreator",
+		DeviceID:  "sessionDeviceID",
+		StateType: "PLAY",
+		QueueHead: 0,
+		QueueTracks: []*entity.QueueTrack{{
+			Index:     0,
+			URI:       "existed_session_uri",
+			SessionID: "sessionID",
+		},
+		},
+	}
+
+	tests := []struct {
+		name                     string
+		sessionID                string
+		body                     string
+		prepareMockPlayerFn      func(m *mock_spotify.MockPlayer)
+		prepareMockPusherFn      func(m *mock_event.MockPusher)
+		prepareMockUserRepoFn    func(m *mock_repository.MockUser)
+		prepareMockSessionRepoFn func(m *mock_repository.MockSession)
+		wantErr                  bool
+		wantCode                 int
+	}{
+		{
+			name:      "正しいuriが渡されると正常に動作する",
+			sessionID: "sessionID",
+			body:      `{"uri": "valid_uri"}`,
+			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
+				m.EXPECT().AddToQueue(gomock.Any(), "valid_uri", "sessionDeviceID").Return(nil)
+			},
+			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
+				m.EXPECT().FindByID("sessionID").Return(session, nil)
+				m.EXPECT().StoreQueueTrack(&entity.QueueTrackToStore{
+					URI:       "valid_uri",
+					SessionID: "sessionID",
+				}).Return(nil)
+			},
+			wantErr:  false,
+			wantCode: http.StatusNoContent,
+		},
+		{
+			name:                     "uriが空の時400",
+			sessionID:                "sessionID",
+			body:                     `{"uri": ""}`,
+			prepareMockPlayerFn:      func(m *mock_spotify.MockPlayer) {},
+			prepareMockPusherFn:      func(m *mock_event.MockPusher) {},
+			prepareMockUserRepoFn:    func(m *mock_repository.MockUser) {},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {},
+			wantErr:                  true,
+			wantCode:                 http.StatusBadRequest,
+		},
+		{
+			name:                  "存在しないsessionIDの時404",
+			sessionID:             "invalidSessionID",
+			body:                  `{"uri": "valid_uri"}`,
+			prepareMockPlayerFn:   func(m *mock_spotify.MockPlayer) {},
+			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
+				m.EXPECT().FindByID("invalidSessionID").Return(nil, entity.ErrSessionNotFound)
+			},
+			wantErr:  true,
+			wantCode: http.StatusNotFound,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// httptestの準備
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(tt.body))
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			c.SetPath("/sessions/:id/queue")
+			c.SetParamNames("id")
+			c.SetParamValues(tt.sessionID)
+
+			// モックの準備
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockPlayer := mock_spotify.NewMockPlayer(ctrl)
+			tt.prepareMockPlayerFn(mockPlayer)
+			mockPusher := mock_event.NewMockPusher(ctrl)
+			tt.prepareMockPusherFn(mockPusher)
+			mockUserRepo := mock_repository.NewMockUser(ctrl)
+			tt.prepareMockUserRepoFn(mockUserRepo)
+			mockSessionRepo := mock_repository.NewMockSession(ctrl)
+			tt.prepareMockSessionRepoFn(mockSessionRepo)
+			uc := usecase.NewSessionUseCase(mockSessionRepo, mockUserRepo, mockPlayer, mockPusher)
+			h := &SessionHandler{
+				uc: uc,
+			}
+			err := h.AddQueue(c)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Playback() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			// ステータスコードのチェック
+			if er, ok := err.(*echo.HTTPError); ok && er.Code != tt.wantCode {
+				t.Errorf("Playback() code = %d, want = %d", rec.Code, tt.wantCode)
+			}
+		})
+	}
+}

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -497,7 +497,7 @@ func TestSessionHandler_AddQueue(t *testing.T) {
 		{
 			name:      "正しいuriが渡されると正常に動作する",
 			sessionID: "sessionID",
-			body:      `{"uri": "valid_uri"}`,
+			body:      `{"uri": "spotify:track:valid_uri"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
 				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:valid_uri", "sessionDeviceID").Return(nil)
 			},


### PR DESCRIPTION
## Related Issue
#19 

## What

- POST /sessions/:id/queue を実装
https://github.com/camphor-/relaym-server/blob/master/docs/api.md#post-sessionsidqueue

## Memo
spotify.AddToQueueの引数が元々trackIDを取るようになっていたのですが、アプリケーション内でtrackURIを使うことが多いと感じたのでspotify.AddToQueueの引数ではtrackURIを受け取り、内部でtrackIDに変換する形にしました。spotify.AddToQueueはそのままに、usecase内でtrackURIをtrackIDに変換するのと迷ったのですが、どちらがいい（もしくは他にこうしたほうが良い）とかありますか？