### PR TITLE
[WebSocket] ADDTRACKイベントとPAUSEイベントの送信処理を実装

### DIFF
--- a/domain/entity/event.go
+++ b/domain/entity/event.go
@@ -16,6 +16,11 @@ var (
 		Type: "PLAY",
 	}
 
+	// EventPause はセッションが一時停止された際に発されるイベントです。
+	EventPause = &Event{
+		Type: "PAUSE",
+	}
+
 	// EventNextTrack はセッションの曲の再生が (正常に) 次の曲に移った際に発されるイベントです。
 	// キューの現在再生している曲の位置が含まれます。
 	EventNextTrack = &Event{

--- a/domain/entity/event.go
+++ b/domain/entity/event.go
@@ -6,6 +6,11 @@ type Event struct {
 }
 
 var (
+	// EventAddTrack はセッションに曲が追加された際に発されるイベントです。
+	EventAddTrack = &Event{
+		Type: "ADDTRACK",
+	}
+
 	// EventPlay はセッションの再生が開始された際に発されるイベントです。
 	EventPlay = &Event{
 		Type: "PLAY",

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -149,6 +149,11 @@ func (s *SessionUseCase) pause(ctx context.Context, sessionID string) error {
 		return fmt.Errorf("update session id=%s: %w", sessionID, err)
 	}
 
+	s.pusher.Push(&event.PushMessage{
+		SessionID: sessionID,
+		Msg:       entity.EventPause,
+	})
+
 	return nil
 }
 

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -55,6 +55,11 @@ func (s *SessionUseCase) AddQueueTrack(ctx context.Context, sessionID string, tr
 		return fmt.Errorf("AddToQueue URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
 	}
 
+	s.pusher.Push(&event.PushMessage{
+		SessionID: sessionID,
+		Msg:       entity.EventAddTrack,
+	})
+
 	return nil
 }
 

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -134,7 +134,12 @@ func TestSessionHandler_Playback(t *testing.T) {
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
 				m.EXPECT().Pause(gomock.Any(), "").Return(entity.ErrActiveDeviceNotFound)
 			},
-			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
+			prepareMockPusherFn: func(m *mock_event.MockPusher) {
+				m.EXPECT().Push(&event.PushMessage{
+					SessionID: "sessionID",
+					Msg:       entity.EventPause,
+				})
+			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
@@ -165,6 +170,10 @@ func TestSessionHandler_Playback(t *testing.T) {
 				m.EXPECT().Pause(gomock.Any(), "").Return(nil)
 			},
 			prepareMockPusherFn: func(m *mock_event.MockPusher) {
+				m.EXPECT().Push(&event.PushMessage{
+					SessionID: "sessionID",
+					Msg:       entity.EventPause,
+				})
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -501,7 +501,12 @@ func TestSessionHandler_AddQueue(t *testing.T) {
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
 				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:valid_uri", "sessionDeviceID").Return(nil)
 			},
-			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
+			prepareMockPusherFn: func(m *mock_event.MockPusher) {
+				m.EXPECT().Push(&event.PushMessage{
+					SessionID: "sessionID",
+					Msg:       entity.EventAddTrack,
+				})
+			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID("sessionID").Return(session, nil)


### PR DESCRIPTION
## Related Issue

#31 

## What

- 曲の追加時にADDTRACKイベントを送信
- 曲の一時停止時にPAUSEイベントを送信

## Memo
<!-- レビュワーに伝えたいことがあれば -->