### PR TITLE
サーバの起動失敗時に終了コード1で終了する

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ func main() {
 	go func() {
 		if err := s.Start(":" + config.Port()); err != nil {
 			s.Logger.Infof("shutting down the server with error: %v", err)
+			os.Exit(1)
 		}
 	}()
 


### PR DESCRIPTION
## Related Issue
なし

## What

- サーバの起動が失敗したときにプロセスが終了していなかったので、終了するように変更

## Memo
<!-- レビュワーに伝えたいことがあれば -->