### PR TITLE
sessionの情報を取得するGET /sessions/:idを実装

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -180,6 +180,7 @@ X-CSRF-Token: relaym
     
 | code | message | 補足 |
 | ---- | -------- | -------- |
+| 400 | empty session id | セッションidがリクエストに含まれていない |
 | 404 | session not found | 指定されたidのセッションが存在しない |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -180,7 +180,6 @@ X-CSRF-Token: relaym
     
 | code | message | 補足 |
 | ---- | -------- | -------- |
-| 400 | empty session id | セッションidがリクエストに含まれていない |
 | 404 | session not found | 指定されたidのセッションが存在しない |
 
 

--- a/domain/entity/track.go
+++ b/domain/entity/track.go
@@ -33,6 +33,7 @@ type CurrentPlayingInfo struct {
 	Playing  bool
 	Progress time.Duration
 	Track    *Track
+	Device   *Device
 }
 
 // Remain は残りの再生時間を計算します。

--- a/domain/mock_spotify/track.go
+++ b/domain/mock_spotify/track.go
@@ -49,17 +49,17 @@ func (mr *MockTrackClientMockRecorder) Search(ctx, q interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockTrackClient)(nil).Search), ctx, q)
 }
 
-// GetTrackFromURI mocks base method
-func (m *MockTrackClient) GetTrackFromURI(ctx context.Context, id string) (*entity.Track, error) {
+// GetTracksFromURI mocks base method
+func (m *MockTrackClient) GetTracksFromURI(ctx context.Context, trackURIs []string) ([]*entity.Track, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTrackFromURI", ctx, id)
-	ret0, _ := ret[0].(*entity.Track)
+	ret := m.ctrl.Call(m, "GetTracksFromURI", ctx, trackURIs)
+	ret0, _ := ret[0].([]*entity.Track)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetTrackFromURI indicates an expected call of GetTrackFromURI
-func (mr *MockTrackClientMockRecorder) GetTrackFromURI(ctx, id interface{}) *gomock.Call {
+// GetTracksFromURI indicates an expected call of GetTracksFromURI
+func (mr *MockTrackClientMockRecorder) GetTracksFromURI(ctx, trackURIs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrackFromURI", reflect.TypeOf((*MockTrackClient)(nil).GetTrackFromURI), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTracksFromURI", reflect.TypeOf((*MockTrackClient)(nil).GetTracksFromURI), ctx, trackURIs)
 }

--- a/domain/mock_spotify/track.go
+++ b/domain/mock_spotify/track.go
@@ -48,3 +48,18 @@ func (mr *MockTrackClientMockRecorder) Search(ctx, q interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockTrackClient)(nil).Search), ctx, q)
 }
+
+// GetTrackFromURI mocks base method
+func (m *MockTrackClient) GetTrackFromURI(ctx context.Context, id string) (*entity.Track, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTrackFromURI", ctx, id)
+	ret0, _ := ret[0].(*entity.Track)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTrackFromURI indicates an expected call of GetTrackFromURI
+func (mr *MockTrackClientMockRecorder) GetTrackFromURI(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTrackFromURI", reflect.TypeOf((*MockTrackClient)(nil).GetTrackFromURI), ctx, id)
+}

--- a/domain/spotify/track.go
+++ b/domain/spotify/track.go
@@ -11,4 +11,5 @@ import (
 // TrackClient はSpotifyの音楽に関連したAPIを呼び出すためのインターフェイスです。
 type TrackClient interface {
 	Search(ctx context.Context, q string) ([]*entity.Track, error)
+	GetTrackFromURI(ctx context.Context, id string) (*entity.Track, error)
 }

--- a/domain/spotify/track.go
+++ b/domain/spotify/track.go
@@ -11,5 +11,5 @@ import (
 // TrackClient はSpotifyの音楽に関連したAPIを呼び出すためのインターフェイスです。
 type TrackClient interface {
 	Search(ctx context.Context, q string) ([]*entity.Track, error)
-	GetTrackFromURI(ctx context.Context, id string) (*entity.Track, error)
+	GetTracksFromURI(ctx context.Context, trackURIs []string) ([]*entity.Track, error)
 }

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	userUC := usecase.NewUserUseCase(spotifyCli, userRepo)
 	authUC := usecase.NewAuthUseCase(spotifyCli, spotifyCli, authRepo, userRepo)
-	sessionUC := usecase.NewSessionUseCase(sessionRepo, userRepo, spotifyCli, hub)
+	sessionUC := usecase.NewSessionUseCase(sessionRepo, userRepo, spotifyCli, spotifyCli, hub)
 	trackUC := usecase.NewTrackUseCase(spotifyCli)
 
 	s := web.NewServer(authUC, userUC, sessionUC, trackUC, hub)

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -21,15 +21,24 @@ func (c *Client) CurrentlyPlaying(ctx context.Context) (*entity.CurrentPlayingIn
 		return nil, errors.New("token not found")
 	}
 	cli := c.auth.NewClient(token)
-	cp, err := cli.PlayerCurrentlyPlaying()
+	ps, err := cli.PlayerState()
 	if convErr := c.convertPlayerError(err); convErr != nil {
 		return nil, fmt.Errorf("spotify api: currently playing: %w", convErr)
 	}
 	return &entity.CurrentPlayingInfo{
-		Playing:  cp.Playing,
-		Progress: time.Duration(cp.Progress) * time.Millisecond,
-		Track:    c.toTrack(cp.Item),
+		Playing:  ps.Playing,
+		Progress: time.Duration(ps.Progress) * time.Millisecond,
+		Track:    c.toTrack(ps.Item),
+		Device:   c.toDevice(ps.Device),
 	}, nil
+}
+
+func (c *Client) toDevice(device spotify.PlayerDevice) *entity.Device {
+	return &entity.Device{
+		ID:           string(device.ID),
+		IsRestricted: device.Restricted,
+		Name:         device.Name,
+	}
 }
 
 // Play は曲を再生し始めるか現在再生途中の曲の再生を再開するAPIです。deviceIDが空の場合はデフォルトのデバイスで再生されます。

--- a/spotify/track.go
+++ b/spotify/track.go
@@ -3,6 +3,7 @@ package spotify
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/camphor-/relaym-server/domain/entity"
@@ -23,6 +24,23 @@ func (c *Client) Search(ctx context.Context, q string) ([]*entity.Track, error) 
 		return nil, fmt.Errorf("search q=%s: %w", q, err)
 	}
 	return c.toTracks(result.Tracks.Tracks), nil
+}
+
+// GetTrackFromURI はSpotify APIを通して、与えられたTrack URIを用い音楽を取得します。
+func (c *Client) GetTrackFromURI(ctx context.Context, trackURI string) (*entity.Track, error) {
+	token, ok := service.GetTokenFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("token not found")
+	}
+
+	id := strings.Replace(trackURI, "spotify:track", "", 1)
+	cli := c.auth.NewClient(token)
+
+	track, err := cli.GetTrack(spotify.ID(id))
+	if err != nil {
+		return nil, fmt.Errorf("get track id=%s: %w", id, err)
+	}
+	return c.toTrack(track), nil
 }
 
 func (c *Client) toTracks(resultTracks []spotify.FullTrack) []*entity.Track {

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -309,13 +309,14 @@ func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*ent
 		return nil, nil, nil, fmt.Errorf("FindByID userID=%s: %w", session.CreatorID, err)
 	}
 
-	tracks := make([]*entity.Track, len(session.QueueTracks))
+	trackURIs := make([]string, len(session.QueueTracks))
 	for i, queueTrack := range session.QueueTracks {
-		track, err := s.trackCli.GetTrackFromURI(ctx, queueTrack.URI)
-		if err != nil {
-			return nil, nil, nil, fmt.Errorf("get track: track_uri=%s: %w", queueTrack.URI, err)
-		}
-		tracks[i] = track
+		trackURIs[i] = queueTrack.URI
+	}
+
+	tracks, err := s.trackCli.GetTracksFromURI(ctx, trackURIs)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("get tracks: track_uris=%s: %w", trackURIs, err)
 	}
 
 	cpi, err := s.playerCli.CurrentlyPlaying(ctx)

--- a/usecase/session_test.go
+++ b/usecase/session_test.go
@@ -300,7 +300,7 @@ func TestSessionUseCase_handleTrackEnd(t *testing.T) {
 			tt.prepareMockUserRepoFn(mockUserRepo)
 			mockSessionRepo := mock_repository.NewMockSession(ctrl)
 			tt.prepareMockSessionRepoFn(mockSessionRepo)
-			s := NewSessionUseCase(mockSessionRepo, mockUserRepo, mockPlayer, mockPusher)
+			s := NewSessionUseCase(mockSessionRepo, mockUserRepo, mockPlayer, nil, mockPusher)
 
 			gotTriggerAfterTrackEnd, gotNextTrack, err := s.handleTrackEnd(context.Background(), tt.sessionID)
 			if (err != nil) != tt.wantErr {

--- a/web/handler/session.go
+++ b/web/handler/session.go
@@ -174,7 +174,7 @@ func (h *SessionHandler) toSessionRes(session *entity.SessionWithUser, device *e
 		},
 		Playback: playbackJSON{
 			State: stateJSON{
-				Type: "STOP",
+				Type: session.StateType.String(),
 			},
 			Device: devices,
 		},

--- a/web/handler/session.go
+++ b/web/handler/session.go
@@ -51,9 +51,6 @@ func (h *SessionHandler) PostSession(c echo.Context) error {
 func (h *SessionHandler) GetSession(c echo.Context) error {
 	ctx := c.Request().Context()
 	id := c.Param("id")
-	if id == "" {
-		return echo.NewHTTPError(http.StatusBadRequest, "empty session id")
-	}
 
 	session, tracks, playingInfo, err := h.uc.GetSession(ctx, id)
 	if err != nil {

--- a/web/handler/session.go
+++ b/web/handler/session.go
@@ -157,9 +157,9 @@ func (h *SessionHandler) SetDevice(c echo.Context) error {
 }
 
 func (h *SessionHandler) toSessionRes(session *entity.SessionWithUser, device *entity.Device, tracks []*entity.Track) *sessionRes {
-	devices := deviceJSON{}
+	var dJ *deviceJSON = nil
 	if device != nil {
-		devices = deviceJSON{
+		dJ = &deviceJSON{
 			ID:           device.ID,
 			IsRestricted: device.IsRestricted,
 			Name:         device.Name,
@@ -176,7 +176,7 @@ func (h *SessionHandler) toSessionRes(session *entity.SessionWithUser, device *e
 			State: stateJSON{
 				Type: session.StateType.String(),
 			},
-			Device: devices,
+			Device: dJ,
 		},
 		Queue: queueJSON{
 			Head:   session.QueueHead,
@@ -199,8 +199,8 @@ type creatorJSON struct {
 }
 
 type playbackJSON struct {
-	State  stateJSON  `json:"state"`
-	Device deviceJSON `json:"device"`
+	State  stateJSON   `json:"state"`
+	Device *deviceJSON `json:"device"`
 }
 type stateJSON struct {
 	Type string `json:"type"`

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -371,7 +371,7 @@ func TestSessionHandler_PostSession(t *testing.T) {
 			State: stateJSON{
 				Type: "STOP",
 			},
-			Device: deviceJSON{},
+			Device: nil,
 		},
 		Queue: queueJSON{
 			Head:   0,
@@ -694,7 +694,7 @@ func TestSessionHandler_GetSession(t *testing.T) {
 			State: stateJSON{
 				Type: "STOP",
 			},
-			Device: deviceJSON{
+			Device: &deviceJSON{
 				ID:           device.ID,
 				IsRestricted: device.IsRestricted,
 				Name:         device.Name,

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -598,7 +598,7 @@ func TestSessionHandler_GetSession(t *testing.T) {
 		Name:      "sessionName",
 		CreatorID: "creatorID",
 		DeviceID:  "sessionDeviceID",
-		StateType: "PLAY",
+		StateType: "STOP",
 		QueueHead: 0,
 		QueueTracks: []*entity.QueueTrack{
 			{
@@ -627,16 +627,18 @@ func TestSessionHandler_GetSession(t *testing.T) {
 		},
 	}
 
-	track := &entity.Track{
-		URI:      "spotify:track:06QTSGUEgcmKwiEJ0IMPig",
-		ID:       "06QTSGUEgcmKwiEJ0IMPig",
-		Name:     "Borderland",
-		Duration: 213066000000,
-		Artists:  artists,
-		URL:      "https://open.spotify.com/track/06QTSGUEgcmKwiEJ0IMPig",
-		Album: &entity.Album{
-			Name:   "Interstate 46 E.P.",
-			Images: albumImages,
+	tracks := []*entity.Track{
+		{
+			URI:      "spotify:track:06QTSGUEgcmKwiEJ0IMPig",
+			ID:       "06QTSGUEgcmKwiEJ0IMPig",
+			Name:     "Borderland",
+			Duration: 213066000000,
+			Artists:  artists,
+			URL:      "https://open.spotify.com/track/06QTSGUEgcmKwiEJ0IMPig",
+			Album: &entity.Album{
+				Name:   "Interstate 46 E.P.",
+				Images: albumImages,
+			},
 		},
 	}
 	device := &entity.Device{
@@ -648,7 +650,7 @@ func TestSessionHandler_GetSession(t *testing.T) {
 	cpi := &entity.CurrentPlayingInfo{
 		Playing:  false,
 		Progress: 0,
-		Track:    track,
+		Track:    tracks[0],
 		Device:   device,
 	}
 
@@ -724,7 +726,7 @@ func TestSessionHandler_GetSession(t *testing.T) {
 			},
 			prepareMockPusherFn: func(m *mock_event.MockPusher) {},
 			prepareMockTrackCliFn: func(m *mock_spotify.MockTrackClient) {
-				m.EXPECT().GetTrackFromURI(gomock.Any(), "spotify:track:06QTSGUEgcmKwiEJ0IMPig").Return(track, nil)
+				m.EXPECT().GetTracksFromURI(gomock.Any(), []string{"spotify:track:06QTSGUEgcmKwiEJ0IMPig"}).Return(tracks, nil)
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {
 				m.EXPECT().FindByID("creatorID").Return(user, nil)
@@ -735,22 +737,6 @@ func TestSessionHandler_GetSession(t *testing.T) {
 			want:     sessionResponse,
 			wantErr:  false,
 			wantCode: http.StatusOK,
-		},
-		{
-			name:      "IDを渡さなかった時400",
-			sessionID: "",
-			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
-			},
-			prepareMockPusherFn: func(m *mock_event.MockPusher) {},
-			prepareMockTrackCliFn: func(m *mock_spotify.MockTrackClient) {
-			},
-			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {
-			},
-			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-			},
-			want:     nil,
-			wantErr:  true,
-			wantCode: http.StatusBadRequest,
 		},
 		{
 			name:      "存在しないsessionIDを渡した時404",

--- a/web/handler/track.go
+++ b/web/handler/track.go
@@ -32,11 +32,11 @@ func (h *TrackHandler) SearchTracks(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	return c.JSON(http.StatusOK, &tracksRes{
-		Tracks: h.toTrackJSON(tracks),
+		Tracks: toTrackJSON(tracks),
 	})
 }
 
-func (h *TrackHandler) toTrackJSON(tracks []*entity.Track) []*trackJSON {
+func toTrackJSON(tracks []*entity.Track) []*trackJSON {
 	trackJSONs := make([]*trackJSON, len(tracks))
 
 	for i, track := range tracks {
@@ -45,11 +45,11 @@ func (h *TrackHandler) toTrackJSON(tracks []*entity.Track) []*trackJSON {
 			ID:       track.ID,
 			Name:     track.Name,
 			Duration: track.Duration.Milliseconds(),
-			Artists:  h.toArtistJSON(track),
+			Artists:  toArtistJSON(track),
 			URL:      track.URL,
 			Album: &albumJSON{
 				Name:   track.Album.Name,
-				Images: h.toAlbumImageJSON(track),
+				Images: toAlbumImageJSON(track),
 			},
 		}
 	}
@@ -57,7 +57,7 @@ func (h *TrackHandler) toTrackJSON(tracks []*entity.Track) []*trackJSON {
 	return trackJSONs
 }
 
-func (h *TrackHandler) toArtistJSON(track *entity.Track) []*artistJSON {
+func toArtistJSON(track *entity.Track) []*artistJSON {
 	artistJSONs := make([]*artistJSON, len(track.Artists))
 	for i, artist := range track.Artists {
 		artistJSONs[i] = &artistJSON{
@@ -68,7 +68,7 @@ func (h *TrackHandler) toArtistJSON(track *entity.Track) []*artistJSON {
 	return artistJSONs
 }
 
-func (h *TrackHandler) toAlbumImageJSON(track *entity.Track) []*albumImageJSON {
+func toAlbumImageJSON(track *entity.Track) []*albumImageJSON {
 	albumImageJSONs := make([]*albumImageJSON, len(track.Album.Images))
 	for i, albumImage := range track.Album.Images {
 		albumImageJSONs[i] = &albumImageJSON{

--- a/web/router.go
+++ b/web/router.go
@@ -59,6 +59,7 @@ func NewServer(authUC *usecase.AuthUseCase, userUC *usecase.UserUseCase, session
 	authedSession.PUT("/:id/devices", sessionHandler.SetDevice)
 
 	noAuthedSession := v3.Group("/sessions")
+	noAuthedSession.GET("/:id", sessionHandler.GetSession)
 	noAuthedSession.PUT("/:id/playback", sessionHandler.Playback)
 	return e
 }


### PR DESCRIPTION
## Related Issue
#48 (#59 )

## What

- GET /sessions/:idを実装
https://github.com/camphor-/relaym-server/blob/master/docs/api.md#get-sessionsid

## Memo
勝手に400（"empty session id"）も追加しちゃったんですけど、idがない状態で渡ってきたときも404の方がよかったですか？？