### PR TITLE
 Stop→Play時に全てのキューをSpotifyに投げて再生を始めることで、今の曲を強制的に中断させて再生を開始させる

### DIFF
--- a/database/session.go
+++ b/database/session.go
@@ -98,7 +98,7 @@ func (r *SessionRepository) Update(session *entity.Session) error {
 
 // StoreQueueTrack はQueueTrackをDBに挿入します。
 func (r *SessionRepository) StoreQueueTrack(queueTrack *entity.QueueTrackToStore) error {
-	if _, err := r.dbMap.Exec("INSERT INTO queue_tracks(`index`, uri, session_id) SELECT COALESCE(MAX('index'),-1)+1, ?, ? from queue_tracks as qt WHERE session_id = ?;", queueTrack.URI, queueTrack.SessionID, queueTrack.SessionID); err != nil {
+	if _, err := r.dbMap.Exec("INSERT INTO queue_tracks(`index`, uri, session_id) SELECT COALESCE(MAX(`index`),-1)+1, ?, ? from queue_tracks as qt WHERE session_id = ?;", queueTrack.URI, queueTrack.SessionID, queueTrack.SessionID); err != nil {
 		return fmt.Errorf("insert queue_tracks: %w", err)
 	}
 	return nil

--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -92,6 +92,27 @@ func (s *Session) IsPlayingCorrectTrack(playingInfo *CurrentPlayingInfo) error {
 	return nil
 }
 
+// ShouldCallAddQueueAPINow は今すぐキューに追加するAPIを叩くかどうか判定します。
+// 最初の再生開始時(Stop→Play時)は一気にキューに追加するけど、それ以外のときは随時追加したいので、
+// それをチェックするために使います。
+func (s *Session) ShouldCallAddQueueAPINow() bool {
+	return s.StateType == Play || s.StateType == Pause
+}
+
+// IsResume は次のStateTypeへの移行がポーズからの再開かどうかを返します、
+func (s *Session) IsResume(nextState StateType) bool {
+	return s.StateType == Pause && nextState == Play
+}
+
+// TrackURIs は track URIのスライスを返します。
+func (s *Session) TrackURIs() []string {
+	uris := make([]string, len(s.QueueTracks))
+	for i := 0; i < len(s.QueueTracks); i++ {
+		uris[i] = s.QueueTracks[i].URI
+	}
+	return uris
+}
+
 type StateType string
 
 const (

--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -99,7 +99,7 @@ func (s *Session) ShouldCallAddQueueAPINow() bool {
 	return s.StateType == Play || s.StateType == Pause
 }
 
-// IsResume は次のStateTypeへの移行がポーズからの再開かどうかを返します、
+// IsResume は次のStateTypeへの移行がポーズからの再開かどうかを返します。
 func (s *Session) IsResume(nextState StateType) bool {
 	return s.StateType == Pause && nextState == Play
 }

--- a/domain/mock_spotify/player.go
+++ b/domain/mock_spotify/player.go
@@ -63,6 +63,20 @@ func (mr *MockPlayerMockRecorder) Play(ctx, deviceID interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Play", reflect.TypeOf((*MockPlayer)(nil).Play), ctx, deviceID)
 }
 
+// PlayWithTracks mocks base method
+func (m *MockPlayer) PlayWithTracks(ctx context.Context, deviceID string, trackURIs []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PlayWithTracks", ctx, deviceID, trackURIs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PlayWithTracks indicates an expected call of PlayWithTracks
+func (mr *MockPlayerMockRecorder) PlayWithTracks(ctx, deviceID, trackURIs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PlayWithTracks", reflect.TypeOf((*MockPlayer)(nil).PlayWithTracks), ctx, deviceID, trackURIs)
+}
+
 // Pause mocks base method
 func (m *MockPlayer) Pause(ctx context.Context, deviceID string) error {
 	m.ctrl.T.Helper()

--- a/domain/mock_spotify/player.go
+++ b/domain/mock_spotify/player.go
@@ -106,29 +106,29 @@ func (mr *MockPlayerMockRecorder) AddToQueue(ctx, trackID, deviceID interface{})
 }
 
 // SetRepeatMode mocks base method
-func (m *MockPlayer) SetRepeatMode(ctx context.Context, on bool) error {
+func (m *MockPlayer) SetRepeatMode(ctx context.Context, on bool, deviceID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetRepeatMode", ctx, on)
+	ret := m.ctrl.Call(m, "SetRepeatMode", ctx, on, deviceID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetRepeatMode indicates an expected call of SetRepeatMode
-func (mr *MockPlayerMockRecorder) SetRepeatMode(ctx, on interface{}) *gomock.Call {
+func (mr *MockPlayerMockRecorder) SetRepeatMode(ctx, on, deviceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRepeatMode", reflect.TypeOf((*MockPlayer)(nil).SetRepeatMode), ctx, on)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRepeatMode", reflect.TypeOf((*MockPlayer)(nil).SetRepeatMode), ctx, on, deviceID)
 }
 
 // SetShuffleMode mocks base method
-func (m *MockPlayer) SetShuffleMode(ctx context.Context, on bool) error {
+func (m *MockPlayer) SetShuffleMode(ctx context.Context, on bool, deviceID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetShuffleMode", ctx, on)
+	ret := m.ctrl.Call(m, "SetShuffleMode", ctx, on, deviceID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetShuffleMode indicates an expected call of SetShuffleMode
-func (mr *MockPlayerMockRecorder) SetShuffleMode(ctx, on interface{}) *gomock.Call {
+func (mr *MockPlayerMockRecorder) SetShuffleMode(ctx, on, deviceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShuffleMode", reflect.TypeOf((*MockPlayer)(nil).SetShuffleMode), ctx, on)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShuffleMode", reflect.TypeOf((*MockPlayer)(nil).SetShuffleMode), ctx, on, deviceID)
 }

--- a/domain/mock_spotify/player.go
+++ b/domain/mock_spotify/player.go
@@ -118,3 +118,17 @@ func (mr *MockPlayerMockRecorder) SetRepeatMode(ctx, on interface{}) *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRepeatMode", reflect.TypeOf((*MockPlayer)(nil).SetRepeatMode), ctx, on)
 }
+
+// SetShuffleMode mocks base method
+func (m *MockPlayer) SetShuffleMode(ctx context.Context, on bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetShuffleMode", ctx, on)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetShuffleMode indicates an expected call of SetShuffleMode
+func (mr *MockPlayerMockRecorder) SetShuffleMode(ctx, on interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShuffleMode", reflect.TypeOf((*MockPlayer)(nil).SetShuffleMode), ctx, on)
+}

--- a/domain/spotify/player.go
+++ b/domain/spotify/player.go
@@ -15,6 +15,6 @@ type Player interface {
 	PlayWithTracks(ctx context.Context, deviceID string, trackURIs []string) error
 	Pause(ctx context.Context, deviceID string) error
 	AddToQueue(ctx context.Context, trackID string, deviceID string) error
-	SetRepeatMode(ctx context.Context, on bool) error
-	SetShuffleMode(ctx context.Context, on bool) error
+	SetRepeatMode(ctx context.Context, on bool, deviceID string) error
+	SetShuffleMode(ctx context.Context, on bool, deviceID string) error
 }

--- a/domain/spotify/player.go
+++ b/domain/spotify/player.go
@@ -16,4 +16,5 @@ type Player interface {
 	Pause(ctx context.Context, deviceID string) error
 	AddToQueue(ctx context.Context, trackID string, deviceID string) error
 	SetRepeatMode(ctx context.Context, on bool) error
+	SetShuffleMode(ctx context.Context, on bool) error
 }

--- a/domain/spotify/player.go
+++ b/domain/spotify/player.go
@@ -12,6 +12,7 @@ import (
 type Player interface {
 	CurrentlyPlaying(ctx context.Context) (*entity.CurrentPlayingInfo, error)
 	Play(ctx context.Context, deviceID string) error
+	PlayWithTracks(ctx context.Context, deviceID string, trackURIs []string) error
 	Pause(ctx context.Context, deviceID string) error
 	AddToQueue(ctx context.Context, trackID string, deviceID string) error
 	SetRepeatMode(ctx context.Context, on bool) error

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -162,6 +162,26 @@ func (c *Client) SetRepeatMode(ctx context.Context, on bool) error {
 	return nil
 }
 
+// SetShuffleMode はシャッフルモードの設定を変更するAPIです。
+// APIが非同期で処理がされるため、リクエストが返ってきてもリピートモードの設定が完了しているとは限りません。
+// 設定が反映されたか確認するには CurrentlyPlaying() を叩く必要があります。
+// プレミアム会員必須
+func (c *Client) SetShuffleMode(ctx context.Context, on bool) error {
+	token, ok := service.GetTokenFromContext(ctx)
+	if !ok {
+		return errors.New("token not found")
+	}
+	cli := c.auth.NewClient(token)
+
+	// TODO : デバイスIDを指定する必要がある場合はいじる
+	opt := &spotify.PlayOptions{DeviceID: nil}
+
+	if err := cli.ShuffleOpt(on, opt); c.convertPlayerError(err) != nil {
+		return fmt.Errorf("spotify api: set repeat mode: %w", c.convertPlayerError(err))
+	}
+	return nil
+}
+
 func (c *Client) convertPlayerError(err error) error {
 	if e, ok := err.(spotify.Error); ok {
 		switch {

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -141,7 +141,7 @@ func (c *Client) AddToQueue(ctx context.Context, trackURI string, deviceID strin
 // APIが非同期で処理がされるため、リクエストが返ってきてもリピートモードの設定が完了しているとは限りません。
 // 設定が反映されたか確認するには CurrentlyPlaying() を叩く必要があります。
 // プレミアム会員必須
-func (c *Client) SetRepeatMode(ctx context.Context, on bool) error {
+func (c *Client) SetRepeatMode(ctx context.Context, on bool, deviceID string) error {
 	token, ok := service.GetTokenFromContext(ctx)
 	if !ok {
 		return errors.New("token not found")
@@ -153,8 +153,11 @@ func (c *Client) SetRepeatMode(ctx context.Context, on bool) error {
 		state = "context"
 	}
 
-	// TODO : デバイスIDを指定する必要がある場合はいじる
 	opt := &spotify.PlayOptions{DeviceID: nil}
+	if deviceID != "" {
+		spotifyID := spotify.ID(deviceID)
+		opt = &spotify.PlayOptions{DeviceID: &spotifyID}
+	}
 
 	if err := cli.RepeatOpt(state, opt); c.convertPlayerError(err) != nil {
 		return fmt.Errorf("spotify api: set repeat mode: %w", c.convertPlayerError(err))
@@ -166,16 +169,18 @@ func (c *Client) SetRepeatMode(ctx context.Context, on bool) error {
 // APIが非同期で処理がされるため、リクエストが返ってきてもリピートモードの設定が完了しているとは限りません。
 // 設定が反映されたか確認するには CurrentlyPlaying() を叩く必要があります。
 // プレミアム会員必須
-func (c *Client) SetShuffleMode(ctx context.Context, on bool) error {
+func (c *Client) SetShuffleMode(ctx context.Context, on bool, deviceID string) error {
 	token, ok := service.GetTokenFromContext(ctx)
 	if !ok {
 		return errors.New("token not found")
 	}
 	cli := c.auth.NewClient(token)
 
-	// TODO : デバイスIDを指定する必要がある場合はいじる
 	opt := &spotify.PlayOptions{DeviceID: nil}
-
+	if deviceID != "" {
+		spotifyID := spotify.ID(deviceID)
+		opt = &spotify.PlayOptions{DeviceID: &spotifyID}
+	}
 	if err := cli.ShuffleOpt(on, opt); c.convertPlayerError(err) != nil {
 		return fmt.Errorf("spotify api: set repeat mode: %w", c.convertPlayerError(err))
 	}

--- a/testdata/e2e.js
+++ b/testdata/e2e.js
@@ -48,9 +48,9 @@ console.assert(createSessionRes.ok,"セッションの作成に失敗しまし�
 const session = await createSessionRes.json()
 console.log(session)
 
-console.log("----------STEP4 : セッションに曲を追加----------")
+console.log("----------STEP4 : セッションに曲を追加(1曲目)----------")
 
-const trackURI = 'spotify:track:49BRCNV7E94s7Q2FUhhT3w'
+const trackURI = 'spotify:track:5uQ0vKy2973Y9IUCd1wMEF'
 const addQueueRes = await fetch(`http://relaym.local:8080/api/v3/sessions/${session.id}/queue`, {
     "headers": {
         "X-CSRF-TOKEN": "a",
@@ -63,7 +63,22 @@ const addQueueRes = await fetch(`http://relaym.local:8080/api/v3/sessions/${sess
 });
 console.assert(addQueueRes.ok,"キューへの追加に失敗しました",addQueueRes.status)
 
-console.log("----------STEP5 : 再生----------")
+console.log("----------STEP5 : セッションに曲を追加(2曲目)----------")
+
+const secondTrackURI = 'spotify:track:49BRCNV7E94s7Q2FUhhT3w'
+const secondAddQueueRes = await fetch(`http://relaym.local:8080/api/v3/sessions/${session.id}/queue`, {
+    "headers": {
+        "X-CSRF-TOKEN": "a",
+        "content-type":"application/json"
+    },
+    "body": `{"uri":"${secondTrackURI}"}`,
+    "method": "POST",
+    "mode": "cors",
+    "credentials": "include"
+});
+console.assert(secondAddQueueRes.ok,"2曲目キューへの追加に失敗しました",secondAddQueueRes.status)
+
+console.log("----------STEP6 : 再生----------")
 
 const playRes = await fetch(`http://relaym.local:8080/api/v3/sessions/${session.id}/playback`, {
     "headers": {
@@ -80,7 +95,7 @@ console.assert(playRes.ok,"曲の再生に失敗しました",playRes.status)
 const sleep = msec => new Promise(resolve => setTimeout(resolve, msec))
 await sleep(5000)
 
-console.log("----------STEP6 : 一時停止----------")
+console.log("----------STEP7 : 一時停止----------")
 
 const pauseRes = await fetch(`http://relaym.local:8080/api/v3/sessions/${session.id}/playback`, {
     "headers": {
@@ -95,7 +110,7 @@ const pauseRes = await fetch(`http://relaym.local:8080/api/v3/sessions/${session
 console.assert(pauseRes.ok,"曲の一時停止に失敗しました",pauseRes.status)
 await sleep(5000)
 
-console.log("----------STEP7 : 再度再生----------")
+console.log("----------STEP8 : 再度再生----------")
 
 const rePlayRes = await fetch(`http://relaym.local:8080/api/v3/sessions/${session.id}/playback`, {
     "headers": {
@@ -108,3 +123,18 @@ const rePlayRes = await fetch(`http://relaym.local:8080/api/v3/sessions/${sessio
     "credentials": "include"
 });
 console.assert(rePlayRes.ok,"曲の再度再生に失敗しました",rePlayRes.status)
+
+console.log("----------STEP9 : セッションに曲を追加(三曲目)----------")
+
+const thirdTrackURI = 'spotify:track:49BRCNV7E94s7Q2FUhhT3w'
+const thirdAddQueueRes = await fetch(`http://relaym.local:8080/api/v3/sessions/${session.id}/queue`, {
+    "headers": {
+        "X-CSRF-TOKEN": "a",
+        "content-type":"application/json"
+    },
+    "body": `{"uri":"${thirdTrackURI}"}`,
+    "method": "POST",
+    "mode": "cors",
+    "credentials": "include"
+});
+console.assert(thirdAddQueueRes.ok,"3曲目のキューへの追加に失敗しました",thirdAddQueueRes.status)

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -52,11 +52,12 @@ func (s *SessionUseCase) AddQueueTrack(ctx context.Context, sessionID string, tr
 		return fmt.Errorf("StoreQueueTrack URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
 	}
 
-	err = s.playerCli.AddToQueue(ctx, trackURI, session.DeviceID)
-	if err != nil {
-		return fmt.Errorf("AddToQueue URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
+	if session.ShouldCallAddQueueAPINow() {
+		err = s.playerCli.AddToQueue(ctx, trackURI, session.DeviceID)
+		if err != nil {
+			return fmt.Errorf("AddToQueue URI=%s, sessionID=%s: %w", trackURI, sessionID, err)
+		}
 	}
-
 	s.pusher.Push(&event.PushMessage{
 		SessionID: sessionID,
 		Msg:       entity.EventAddTrack,
@@ -109,8 +110,14 @@ func (s *SessionUseCase) play(ctx context.Context, sessionID string) error {
 	// TODO: キューに曲がなかったら再生できないようにする
 
 	// TODO : デバイスIDをどっかから読み込む
-	if err := s.playerCli.Play(ctx, ""); err != nil {
-		return fmt.Errorf("call play api: %w", err)
+	if sess.IsResume(entity.Play) {
+		if err := s.playerCli.Play(ctx, ""); err != nil {
+			return fmt.Errorf("call play api: %w", err)
+		}
+	} else {
+		if err := s.playerCli.PlayWithTracks(ctx, "", sess.TrackURIs()); err != nil {
+			return fmt.Errorf("call play api: %w", err)
+		}
 	}
 
 	if err := sess.MoveToPlay(); err != nil {
@@ -246,8 +253,9 @@ func (s *SessionUseCase) handleTrackEnd(ctx context.Context, sessionID string) (
 		SessionID: sessionID,
 		Msg:       entity.EventNextTrack,
 	})
-
 	triggerAfterTrackEnd = s.tm.CreateTimer(sessionID, playingInfo.Remain()+syncCheckOffset)
+	fmt.Println(playingInfo.Remain())
+
 	return triggerAfterTrackEnd, true, nil
 
 }

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -109,6 +109,14 @@ func (s *SessionUseCase) play(ctx context.Context, sessionID string) error {
 
 	// TODO: キューに曲がなかったら再生できないようにする
 
+	if err := s.playerCli.SetRepeatMode(ctx, false); err != nil {
+		return fmt.Errorf("call set repeat off api: %w", err)
+	}
+
+	if err := s.playerCli.SetShuffleMode(ctx, false); err != nil {
+		return fmt.Errorf("call set repeat off api: %w", err)
+	}
+
 	// TODO : デバイスIDをどっかから読み込む
 	if sess.IsResume(entity.Play) {
 		if err := s.playerCli.Play(ctx, ""); err != nil {
@@ -116,7 +124,7 @@ func (s *SessionUseCase) play(ctx context.Context, sessionID string) error {
 		}
 	} else {
 		if err := s.playerCli.PlayWithTracks(ctx, "", sess.TrackURIs()); err != nil {
-			return fmt.Errorf("call play api: %w", err)
+			return fmt.Errorf("call play ap with tracks %v: %w", sess.TrackURIs(), err)
 		}
 	}
 

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -124,7 +124,7 @@ func (s *SessionUseCase) play(ctx context.Context, sessionID string) error {
 		}
 	} else {
 		if err := s.playerCli.PlayWithTracks(ctx, "", sess.TrackURIs()); err != nil {
-			return fmt.Errorf("call play ap with tracks %v: %w", sess.TrackURIs(), err)
+			return fmt.Errorf("call play api with tracks %v: %w", sess.TrackURIs(), err)
 		}
 	}
 

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -109,11 +109,11 @@ func (s *SessionUseCase) play(ctx context.Context, sessionID string) error {
 
 	// TODO: キューに曲がなかったら再生できないようにする
 
-	if err := s.playerCli.SetRepeatMode(ctx, false); err != nil {
+	if err := s.playerCli.SetRepeatMode(ctx, false, ""); err != nil {
 		return fmt.Errorf("call set repeat off api: %w", err)
 	}
 
-	if err := s.playerCli.SetShuffleMode(ctx, false); err != nil {
+	if err := s.playerCli.SetShuffleMode(ctx, false, ""); err != nil {
 		return fmt.Errorf("call set repeat off api: %w", err)
 	}
 

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -62,7 +62,7 @@ func TestSessionHandler_Playback(t *testing.T) {
 			sessionID: "sessionID",
 			body:      `{"state": "PLAY"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
-				m.EXPECT().SetRepeatMode(gomock.Any(), false).Return(entity.ErrActiveDeviceNotFound)
+				m.EXPECT().SetRepeatMode(gomock.Any(), false, "").Return(entity.ErrActiveDeviceNotFound)
 
 			},
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
@@ -85,8 +85,8 @@ func TestSessionHandler_Playback(t *testing.T) {
 			sessionID: "sessionID",
 			body:      `{"state": "PLAY"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
-				m.EXPECT().SetRepeatMode(gomock.Any(), false).Return(nil)
-				m.EXPECT().SetShuffleMode(gomock.Any(), false).Return(nil)
+				m.EXPECT().SetRepeatMode(gomock.Any(), false, "").Return(nil)
+				m.EXPECT().SetShuffleMode(gomock.Any(), false, "").Return(nil)
 				m.EXPECT().PlayWithTracks(gomock.Any(), "",
 					[]string{"spotify:track:5uQ0vKy2973Y9IUCd1wMEF", "spotify:track:49BRCNV7E94s7Q2FUhhT3w"}).Return(nil)
 			},
@@ -129,9 +129,9 @@ func TestSessionHandler_Playback(t *testing.T) {
 			sessionID: "sessionID",
 			body:      `{"state": "PLAY"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
-				m.EXPECT().SetRepeatMode(gomock.Any(), false).Return(nil)
+				m.EXPECT().SetRepeatMode(gomock.Any(), false, "").Return(nil)
 
-				m.EXPECT().SetShuffleMode(gomock.Any(), false).Return(nil)
+				m.EXPECT().SetShuffleMode(gomock.Any(), false, "").Return(nil)
 				m.EXPECT().Play(gomock.Any(), "").Return(nil)
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -62,7 +62,8 @@ func TestSessionHandler_Playback(t *testing.T) {
 			sessionID: "sessionID",
 			body:      `{"state": "PLAY"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
-				m.EXPECT().Play(gomock.Any(), "").Return(entity.ErrActiveDeviceNotFound)
+				m.EXPECT().SetRepeatMode(gomock.Any(), false).Return(entity.ErrActiveDeviceNotFound)
+
 			},
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
@@ -84,6 +85,8 @@ func TestSessionHandler_Playback(t *testing.T) {
 			sessionID: "sessionID",
 			body:      `{"state": "PLAY"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
+				m.EXPECT().SetRepeatMode(gomock.Any(), false).Return(nil)
+				m.EXPECT().SetShuffleMode(gomock.Any(), false).Return(nil)
 				m.EXPECT().PlayWithTracks(gomock.Any(), "",
 					[]string{"spotify:track:5uQ0vKy2973Y9IUCd1wMEF", "spotify:track:49BRCNV7E94s7Q2FUhhT3w"}).Return(nil)
 			},
@@ -126,6 +129,9 @@ func TestSessionHandler_Playback(t *testing.T) {
 			sessionID: "sessionID",
 			body:      `{"state": "PLAY"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
+				m.EXPECT().SetRepeatMode(gomock.Any(), false).Return(nil)
+
+				m.EXPECT().SetShuffleMode(gomock.Any(), false).Return(nil)
 				m.EXPECT().Play(gomock.Any(), "").Return(nil)
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},

--- a/web/router.go
+++ b/web/router.go
@@ -59,9 +59,9 @@ func NewServer(authUC *usecase.AuthUseCase, userUC *usecase.UserUseCase, session
 	authedSession.POST("", sessionHandler.PostSession)
 	authedSession.PUT("/:id/devices", sessionHandler.SetDevice)
 	authedSession.POST("/:id/queue", sessionHandler.AddQueue)
+	authedSession.PUT("/:id/playback", sessionHandler.Playback)
 
 	noAuthedSession := v3.Group("/sessions")
 	noAuthedSession.GET("/:id", sessionHandler.GetSession)
-	noAuthedSession.PUT("/:id/playback", sessionHandler.Playback)
 	return e
 }


### PR DESCRIPTION
## Related Issue

close #20 
close #66 

## What

- 今までは /queue APIが呼ばれるたびにSpotifyのAPIを呼んでいたが、これからは再生開始した後だけ毎回呼ばれるようにし、再生される前のものは再生開始時にバルクでキューに積むようにする
	- これのおかげで、全く違う曲を再生していたときに /playback で再生を始めるとキューの1曲目が再生されるようになる
	- ついでに次の曲への自動で遷移する
- 間違ってたSQLを修正

## Memo
<!-- レビュワーに伝えたいことがあれば -->