### PR TITLE
NextTrackイベント時にheadの値を送信するようにする

### DIFF
--- a/domain/entity/event.go
+++ b/domain/entity/event.go
@@ -3,6 +3,7 @@ package entity
 // Event はクライアントに送信するイベントを表します。
 type Event struct {
 	Type string `json:"type"`
+	Head *int   `json:"head,omitempty"`
 }
 
 var (
@@ -21,12 +22,6 @@ var (
 		Type: "PAUSE",
 	}
 
-	// EventNextTrack はセッションの曲の再生が (正常に) 次の曲に移った際に発されるイベントです。
-	// キューの現在再生している曲の位置が含まれます。
-	EventNextTrack = &Event{
-		Type: "NEXTTRACK",
-	}
-
 	// EventStop は全ての曲の再生が終了した際に発されるイベントです。
 	EventStop = &Event{
 		Type: "STOP",
@@ -38,3 +33,12 @@ var (
 		Type: "INTERRUPT",
 	}
 )
+
+// NewEventNextTrack はセッションの曲の再生が (正常に) 次の曲に移った際に発されるイベントを生成します。
+// キューの現在再生している曲の位置が含まれます。
+func NewEventNextTrack(head int) *Event {
+	return &Event{
+		Type: "NEXTTRACK",
+		Head: &head,
+	}
+}

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -244,7 +244,7 @@ func (s *SessionUseCase) handleTrackEnd(ctx context.Context, sessionID string) (
 	}
 	s.pusher.Push(&event.PushMessage{
 		SessionID: sessionID,
-		Msg:       entity.EventNextTrack,
+		Msg:       entity.NewEventNextTrack(sess.QueueHead),
 	})
 
 	triggerAfterTrackEnd = s.tm.CreateTimer(sessionID, playingInfo.Remain()+syncCheckOffset)

--- a/usecase/session_test.go
+++ b/usecase/session_test.go
@@ -98,7 +98,7 @@ func TestSessionUseCase_handleTrackEnd(t *testing.T) {
 			prepareMockPusherFn: func(m *mock_event.MockPusher) {
 				m.EXPECT().Push(&event.PushMessage{
 					SessionID: "sessionID",
-					Msg:       entity.EventNextTrack,
+					Msg:       entity.NewEventNextTrack(1),
 				})
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},


### PR DESCRIPTION
## Related Issue

close #31 

## What

- NextTrackイベント時にheadの値を送信するようにする

## Memo
<!-- レビュワーに伝えたいことがあれば -->