### PR TITLE
GetSession周りのバグの修正

### DIFF
--- a/spotify/track.go
+++ b/spotify/track.go
@@ -28,6 +28,9 @@ func (c *Client) Search(ctx context.Context, q string) ([]*entity.Track, error) 
 
 // GetTrackFromURI はSpotify APIを通して、与えられたTrack URIを用い音楽を取得します。
 func (c *Client) GetTracksFromURI(ctx context.Context, trackURIs []string) ([]*entity.Track, error) {
+	if len(trackURIs) == 0 {
+		return nil, nil
+	}
 	token, ok := service.GetTokenFromContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("token not found")
@@ -64,6 +67,9 @@ func (c *Client) toTracks(resultTracks []spotify.FullTrack) []*entity.Track {
 }
 
 func (c *Client) toTrack(fullTrack *spotify.FullTrack) *entity.Track {
+	if fullTrack == nil {
+		return nil
+	}
 	return &entity.Track{
 		URI:      string(fullTrack.URI),
 		ID:       fullTrack.ID.String(),

--- a/web/handler/session.go
+++ b/web/handler/session.go
@@ -57,6 +57,7 @@ func (h *SessionHandler) GetSession(c echo.Context) error {
 		if errors.Is(err, entity.ErrSessionNotFound) {
 			return echo.NewHTTPError(http.StatusNotFound)
 		}
+		c.Logger().Debugf("GetSession: %v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 	return c.JSON(http.StatusOK, h.toSessionRes(session, playingInfo.Device, tracks))

--- a/web/router.go
+++ b/web/router.go
@@ -57,7 +57,7 @@ func NewServer(authUC *usecase.AuthUseCase, userUC *usecase.UserUseCase, session
 	authedSession.POST("/:id/queue", sessionHandler.AddQueue)
 
 	SessionWithCreatorToken := v3.Group("/sessions/:id", NewCreatorTokenMiddleware(authUC).SetCreatorTokenToContext)
-	SessionWithCreatorToken.GET("/", sessionHandler.GetSession)
+	SessionWithCreatorToken.GET("", sessionHandler.GetSession)
 	SessionWithCreatorToken.GET("/search", trackHandler.SearchTracks)
 	SessionWithCreatorToken.PUT("/playback", sessionHandler.Playback)
 	return e


### PR DESCRIPTION
## Related Issue
#82 

## What

- 空の配列がGetTracksFromURIのtrackURIsに渡されるとspotifyAPIがerrを返してしまう（`invalid id`を返すのでnilであることを受け取れない）のでその手前でtrackURIsが空であるかをチェック
- toTrackにnilが渡されるとダメなのでチェック（Trackが空のときにGetSessionを叩くとCurrentlyPlayingでtoTrackをnilで呼び出してしまう）
- GetSessionのrouteが間違ってるので修正

## Memo
ワイが犯人です（どげざ