### PR TITLE
devのdockerImageの名前をドカッと変更した

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Publish Docker
         uses: elgohr/Publish-Docker-Github-Action@2.12
         with:
-          name: relaym-server
+          name: relaym-server-dev
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           registry: registry.camph.net

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   relaym-server:
-    image: registry.camph.net/relaym-server:latest
+    image: registry.camph.net/relaym-server-dev:latest
     container_name: relaym-server-dev
     networks:
       - microservices

--- a/docs/development.md
+++ b/docs/development.md
@@ -122,5 +122,5 @@ Spotifyのクライアントを起動しているかどうかや再生してい�
 ローカルで起動したAPIサーバに対して、簡単なシナリオを元にしたAPIリクエストを送信することができます。
 
 1. `make serve`
-1. Chromeで `http://relaym.local:8080/api/v3/login` にアクセスしてログイン処理を実行
+1. Chromeで http://relaym.local:8080/api/v3/login にアクセスしてログイン処理を実行
 1. http://relaym.local:8080/* を開いた状態でChrome Dev Consoleに [e2e.js](../testdata/e2e.js)を貼り付ける。


### PR DESCRIPTION
## Related Issue
#100 

## What

- devのdockerimageをrelaym-server-devに変更
- なんとなくdevelopment.mdのloginのlinkが直で押せたほうが楽だなぁと日頃思っていたのでしれっと変更

## Memo
<!-- レビュワーに伝えたいことがあれば -->