### PR TITLE
キューがからのときにセッションの同期チェックメソッドがpanicになっていた問題を修正

### DIFF
--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -97,6 +97,18 @@ func (s *Session) GoNextTrack() error {
 // IsPlayingCorrectTrack は現在の再生状況がセッションの状況と一致しているかチェックします。
 func (s *Session) IsPlayingCorrectTrack(playingInfo *CurrentPlayingInfo) error {
 	logger := log.New()
+	if s.StateType == Stop {
+		return nil
+	}
+
+	if playingInfo == nil {
+		logger.Infoj(map[string]interface{}{
+			"message":    "session should be playing but not playing",
+			"queueTrack": s.QueueTracks[s.QueueHead].URI,
+		})
+		return fmt.Errorf("session should be playing: queue track %s, but not playing: %w", s.QueueTracks[s.QueueHead].URI, ErrSessionPlayingDifferentTrack)
+	}
+
 	if playingInfo.Track == nil || s.QueueTracks[s.QueueHead].URI != playingInfo.Track.URI {
 		logger.Infoj(map[string]interface{}{
 			"message":      "session playing different track",

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -401,7 +401,7 @@ func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*ent
 		return nil, nil, nil, fmt.Errorf("CurrentlyPlaying: %w", err)
 	}
 
-	if err := session.IsPlayingCorrectTrack(cpi); session.StateType != entity.Stop && err != nil {
+	if err := session.IsPlayingCorrectTrack(cpi); err != nil {
 		s.tm.StopTimer(sessionID)
 		if interErr := s.handleInterrupt(session); interErr != nil {
 			return nil, nil, nil, fmt.Errorf("check whether playing correct track: handle interrupt: %v: %w", interErr, err)


### PR DESCRIPTION
## Related Issue

## What

- Stopならnilを返すように修正
- Stop以外でplayingInfoがnilならエラーにする

## Logs

```
2020-06-28T05:31:42.930354361Z {"time":"2020-06-28T05:31:42.93002584Z","level":"-","prefix":"echo","file":"recover.go","line":"73","message":"[PANIC RECOVER] runtime error: index out of range [0] with length 0 goroutine 187 [running]:\ngithub.com/labstack/echo/v4/middleware.RecoverWithConfig.func1.1.1(0x9cbf10, 0x1000, 0x0, 0xa77780, 0xc000438140)\n\t/go/pkg/mod/github.com/labstack/echo/v4@v4.1.16/middleware/recover.go:71 +0xee\npanic(0x9700e0, 0xc000399400)\n\t/usr/local/go/src/runtime/panic.go:969 +0x166\ngithub.com/camphor-/relaym-server/domain/entity.(*Session).IsPlayingCorrectTrack(0xc000370150, 0xc0000bbdc0, 0xc000193530, 0xc0000bbdc0)\n\t/go/src/github.com/camphor-/relaym-server/domain/entity/session.go:103 +0x402\ngithub.com/camphor-/relaym-server/usecase.(*SessionUseCase).GetSession(0xc000210180, 0xa6c320, 0xc000193530, 0xc00002a2e5, 0x24, 0xc000267401, 0xc000193530, 0xc000267498, 0x40ca98, 0x80, ...)\n\t/go/src/github.com/camphor-/relaym-server/usecase/session.go:404 +0x542\ngithub.com/camphor-/relaym-server/web/handler.(*SessionHandler).GetSession(0xc00020c088, 0xa77780, 0xc000438140, 0xc000193530, 0xc000346060)\n\t/go/src/github.com/camphor-/relaym-server/web/handler/session.go:60 +0xe3\ngithub.com/camphor-/relaym-server/web.(*CreatorTokenMiddleware).SetCreatorTokenToContext.func1(0xa77780, 0xc000438140, 0x10, 0x8ea040)\n\t/go/src/github.com/camphor-/relaym-server/web/sessionToken_middleware.go:52 +0xa34\ngithub.com/labstack/echo/v4.(*Echo).add.func1(0xa77780, 0xc000438140, 0x9b5e1d, 0x20)\n\t/go/pkg/mod/github.com/labstack/echo/v4@v4.1.16/echo.go:512 +0x8a\ngithub.com/labstack/echo/v4/middleware.CORSWithConfig.func1.1(0xa77780, 0xc000438140, 0xc0001c6201, 0xc0004c68e8)\n\t/go/pkg/mod/github.com/labstack/echo/v4@v4.1.16/middleware/cors.go:121 +0x477\ngithub.com/labstack/echo/v4/middleware.CSRFWithConfig.func1.1(0xa77780, 0xc000438140, 0x0, 0xc0004c69d8)\n\t/go/pkg/mod/github.com/labstack/echo/v4@v4.1.16/middleware/csrf.go:122 +0x91d\ngithub.com/labstack/echo/v4/middleware.RecoverWithConfig.func1.1(0xa77780, 0xc000438140, 0x0, 0x0)\n\t/go/pkg/mod/github.com/labstack/echo/v4@v4.1.16/middleware/recover.go:78 +0x12a\ngithub.com/labstack/echo/v4/middleware.LoggerWithConfig.func2.1(0xa77780, 0xc000438140, 0x0, 0x0)\n\t/go/pkg/mod/github.com/labstack/echo/v4@v4.1.16/middleware/logger.go:117 +0x130\ngithub.com/labstack/echo/v4.(*Echo).ServeHTTP(0xc00022e000, 0xa6ade0, 0xc0003b2b60, 0xc000159400)\n\t/go/pkg/mod/github.com/labstack/echo/v4@v4.1.16/echo.go:623 +0x16c\nnet/http.serverHandler.ServeHTTP(0xc00022a000, 0xa6ade0, 0xc0003b2b60, 0xc000159400)\n\t/usr/local/go/src/net/http/server.go:2807 +0xa3\nnet/http.(*conn).serve(0xc0004388c0, 0xa6c260, 0xc0001898c0)\n\t/usr/local/go/src/net/http/server.go:1895 +0x86c\ncreated by net/http.(*Server).Serve\n\t/usr/local/go/src/net/http/server.go:2933 +0x35c\n\ngoroutine 1 [chan receive, 1402 minutes]:\nmain.main()\n\t/go/src/github.com/camphor-/relaym-server/main.go:63 +0x5c0\n\ngoroutine 18 [select, 1402 minutes]:\ndatabase/sql.(*DB).connectionOpener(0xc000120000, 0xa6c260, 0xc0000b0800)\n\t/usr/local/go/src/database/sql/sql.go:1052 +0xe8\ncreated by database/sql.OpenDB\n\t/usr/local/go/src/database/sql/sql.go:722 +0x15d\n\ngoroutine 19 [select]:\ndatabase/sql.(*DB).connectionResetter(0xc000120000, 0xa6c260, 0xc0000b0800)\n\t/usr/local/go/src/database/sql/sql.go:1065 +0xfb\ncreated by database/sql.OpenDB\n\t/usr/local/go/src/database/sql/sql.go:723 +0x193\n\ngoroutine 100 [select, 11 minutes]:\ngithub.com/go-sql-driver/mysql.(*mysqlConn).startWatcher.func1(0xc0000af260, 0xc0000c66c0, 0xc000404180)\n\t/go/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/connection.go:621 +0xbf\ncreated by github.com/go-sql-driver/mysql.(*mysqlConn).startWatcher\n\t/go/pkg/mod/github.com/go-sql-driver/mysql@v1.5.0/connection.go:618 +0xbe\n\ngoroutine 33 [select, 1402 minutes]:\ngithub.com/camphor-/relaym-server/web/ws.(*Hub).Run(0xc00020e020)\n\t/go/src/github.com/camphor-/relaym-server/web/ws/hub.go:63 +0x10a\ncreated by main.main\n\t/go/src/github.com/camphor-/relaym-server/main.go:36 +0x1e3\n\ngoroutine 34 [IO wait]:\ninternal/poll.runtime_pollWait(0x7f7d6b34ce88, 0x72, 0x0)\n\t/usr/local/go/src/runtime/netpoll.go:203 +0x55\ninternal/poll.(*pollDesc).wait(0xc000204298, 0x72, 0x0, 0x0, 0x9a8b41)\n\t/usr/local/go/src/internal/poll/fd_poll_runtime.go:87 +0x45\ninternal/poll.(*pollDesc).waitRe\n"}
2020-06-28T05:31:42.930507599Z {"time":"2020-06-28T05:31:42.930148686Z","id":"","remote_ip":"58.90.106.211","host":"relaym-server-dev.camph.net","method":"GET","uri":"/api/v3/sessions/baa53ee8-627c-4285-9ac0-54194ee45355","user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36","status":500,"error":"","latency":110779356,"latency_human":"110.779356ms","bytes_in":0,"bytes_out":36}
```

## Memo
<!-- レビュワーに伝えたいことがあれば -->