### PR TITLE
websocket接続時にHTTPリクエストのログを表示する

### DIFF
--- a/web/handler/websocket.go
+++ b/web/handler/websocket.go
@@ -2,7 +2,9 @@ package handler
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
+	"net/http/httputil"
 
 	"github.com/camphor-/relaym-server/domain/entity"
 	"github.com/camphor-/relaym-server/log"
@@ -51,6 +53,9 @@ func (h *WebSocketHandler) WebSocket(c echo.Context) error {
 		logger.Errorj(map[string]interface{}{"message:": "can not connect to pusher", "error": err.Error()})
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
+
+	req, _ := httputil.DumpRequest(c.Request(), true)
+	fmt.Println(string(req))
 
 	wsConn, err := h.upgrader.Upgrade(c.Response(), c.Request(), nil)
 	if err != nil {


### PR DESCRIPTION
## Related Issue

## What

- websocket接続時にHTTPリクエストのログを表示する

```
GET /api/v3/sessions/57ea18a2-966e-492b-b24c-411ed75599de/ws HTTP/1.1
Host: relaym.local:8080
Accept-Encoding: gzip, deflate
Accept-Language: ja,en;q=0.9
Cache-Control: no-cache
Connection: Upgrade
Origin: http://relaym.local:3000
Pragma: no-cache
Sec-Websocket-Extensions: permessage-deflate; client_max_window_bits
Sec-Websocket-Key: 8HDwAb68bAquOji+WiIw4g==
Sec-Websocket-Version: 13
Upgrade: websocket
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.97 Safari/537.36

```

## Memo
<!-- レビュワーに伝えたいことがあれば -->