### PR TITLE
docker logs で色がつくようにtty:trueをセットする

### DIFF
--- a/docker/docker-compose.base.yml
+++ b/docker/docker-compose.base.yml
@@ -4,6 +4,7 @@ services:
     env_file:
       - ../${ENV_FILE}
     restart: always
+    tty: true
     networks:
       - relaym-network
 networks:


### PR DESCRIPTION
## Related Issue

https://github.com/docker/compose/issues/2231

## What

- なんと `tty: true`  をつけるだけでdocker logs でも色がつくのです

<img width="1434" alt="スクリーンショット 2020-06-29 19 44 01" src="https://user-images.githubusercontent.com/30015728/85997848-05245b80-ba45-11ea-896c-86183bd9df37.png">
<img width="1434" alt="スクリーンショット 2020-06-29 19 44 14" src="https://user-images.githubusercontent.com/30015728/85997858-081f4c00-ba45-11ea-81e8-1e350376e168.png">





## Memo
<!-- レビュワーに伝えたいことがあれば -->