### PR TITLE
「次に再生される曲」周りの色々な問題を†完全に解決†した

### DIFF
--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -121,9 +121,9 @@ func (s *Session) IsPlayingCorrectTrack(playingInfo *CurrentPlayingInfo) error {
 }
 
 // ShouldCallAddQueueAPINow は今すぐキューに追加するAPIを叩くかどうか判定します。
-// 最後の曲の再生中に曲を新たに追加された場合はキューに新たに追加したいので、それをチェックするために使います。
+// 最後の曲もしくは最後から二番目の曲の再生中に曲を新たに追加された場合はSpotifyのキューに新たに追加したいので、それをチェックするために使います。
 func (s *Session) ShouldCallAddQueueAPINow() bool {
-	return (len(s.QueueTracks) - s.QueueHead) < 3
+	return ((len(s.QueueTracks) - s.QueueHead) < 3) && (s.StateType == Play || s.StateType == Pause)
 }
 
 // IsResume は次のStateTypeへの移行がポーズからの再開かどうかを返します。

--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -150,7 +150,6 @@ func (s *Session) TrackURIsShouldBeAddedWhenStopToPlay() ([]string, error) {
 
 // TrackURIShouldBeAddedWhenHandleTrackEnd はある一曲の再生が終わったときにSpotifyのキューに追加するTrackURIを抽出します。
 func (s *Session) TrackURIShouldBeAddedWhenHandleTrackEnd() string {
-	// TODO: 最後の曲の再生中に曲を追加された時の対応
 	if (len(s.QueueTracks) - s.QueueHead) == 1 {
 		return ""
 	}

--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -138,10 +138,10 @@ func (s *Session) TrackURIsShouldBeAddedWhenStopToPlay() ([]string, error) {
 	}
 
 	var uris []string
-	for i := 0; i < 2; i++ {
+	for i := 0; i < 3; i++ {
 		trackIndex := i + s.QueueHead
 		uris = append(uris, s.QueueTracks[trackIndex].URI)
-		if (len(s.QueueTracks) - s.QueueHead) == 1 {
+		if (len(s.QueueTracks) - s.QueueHead) == i+1 {
 			break
 		}
 	}

--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -121,10 +121,9 @@ func (s *Session) IsPlayingCorrectTrack(playingInfo *CurrentPlayingInfo) error {
 }
 
 // ShouldCallAddQueueAPINow は今すぐキューに追加するAPIを叩くかどうか判定します。
-// 最初の再生開始時(Stop→Play時)は一気にキューに追加するけど、それ以外のときは随時追加したいので、
-// それをチェックするために使います。
+// 最後の曲の再生中に曲を新たに追加された場合はキューに新たに追加したいので、それをチェックするために使います。
 func (s *Session) ShouldCallAddQueueAPINow() bool {
-	return s.StateType == Play || s.StateType == Pause
+	return s.QueueHead+1 == len(s.QueueTracks)
 }
 
 // IsResume は次のStateTypeへの移行がポーズからの再開かどうかを返します。
@@ -138,12 +137,25 @@ func (s *Session) TrackURIsShouldBeAddedWhenStopToPlay() ([]string, error) {
 		return []string{}, fmt.Errorf("can not to move to play: %w", err)
 	}
 
-	uris := make([]string, len(s.QueueTracks)-s.QueueHead)
-	for i := 0; i < len(s.QueueTracks)-s.QueueHead; i++ {
+	var uris []string
+	for i := 0; i < 2; i++ {
 		trackIndex := i + s.QueueHead
-		uris[i] = s.QueueTracks[trackIndex].URI
+		uris = append(uris, s.QueueTracks[trackIndex].URI)
+		if (len(s.QueueTracks) - s.QueueHead) == 1 {
+			break
+		}
 	}
 	return uris, nil
+}
+
+// TrackURIShouldBeAddedWhenHandleTrackEnd はある一曲の再生が終わったときにSpotifyのキューに追加するTrackURIを抽出します。
+func (s *Session) TrackURIShouldBeAddedWhenHandleTrackEnd() string {
+	// TODO: 最後の曲の再生中に曲を追加された時の対応
+	if (len(s.QueueTracks) - s.QueueHead) == 1 {
+		return ""
+	}
+	index := s.QueueHead + 2
+	return s.QueueTracks[index].URI
 }
 
 // canMoveFromStopToPlay はセッションのStateTypeをStopからPlayに状態遷移しても良いかどうか返します。

--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -123,7 +123,7 @@ func (s *Session) IsPlayingCorrectTrack(playingInfo *CurrentPlayingInfo) error {
 // ShouldCallAddQueueAPINow は今すぐキューに追加するAPIを叩くかどうか判定します。
 // 最後の曲の再生中に曲を新たに追加された場合はキューに新たに追加したいので、それをチェックするために使います。
 func (s *Session) ShouldCallAddQueueAPINow() bool {
-	return s.QueueHead+1 == len(s.QueueTracks)
+	return (len(s.QueueTracks) - s.QueueHead) < 3
 }
 
 // IsResume は次のStateTypeへの移行がポーズからの再開かどうかを返します。
@@ -150,7 +150,7 @@ func (s *Session) TrackURIsShouldBeAddedWhenStopToPlay() ([]string, error) {
 
 // TrackURIShouldBeAddedWhenHandleTrackEnd はある一曲の再生が終わったときにSpotifyのキューに追加するTrackURIを抽出します。
 func (s *Session) TrackURIShouldBeAddedWhenHandleTrackEnd() string {
-	if (len(s.QueueTracks) - s.QueueHead) == 1 {
+	if (len(s.QueueTracks) - s.QueueHead) < 3 {
 		return ""
 	}
 	index := s.QueueHead + 2

--- a/domain/entity/session_test.go
+++ b/domain/entity/session_test.go
@@ -376,6 +376,26 @@ func TestSession_TrackURIsShouldBeAddedWhenStopToPlay(t *testing.T) {
 			want:    []string{"0", "1"},
 			wantErr: false,
 		},
+		{
+			name: "キューに4曲追加して、まだ再生を始めていない時は長さ2のスライス",
+			s: &Session{
+				QueueTracks: []*QueueTrack{{URI: "0"}, {URI: "1"}, {URI: "2"}, {URI: "3"}},
+				QueueHead:   0,
+				StateType:   Stop,
+			},
+			want:    []string{"0", "1"},
+			wantErr: false,
+		},
+		{
+			name: "キューに4曲追加して、まだ再生を始めていない時は長さ2のスライス",
+			s: &Session{
+				QueueTracks: []*QueueTrack{{URI: "0"}, {URI: "1"}, {URI: "2"}, {URI: "3"}},
+				QueueHead:   0,
+				StateType:   Stop,
+			},
+			want:    []string{"0", "1"},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -387,6 +407,45 @@ func TestSession_TrackURIsShouldBeAddedWhenStopToPlay(t *testing.T) {
 
 			if !cmp.Equal(got, tt.want) {
 				t.Errorf("TrackURIsShouldBeAddedWhenStartPlay() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSession_TrackURIShouldBeAddedWhenHandleTrackEnd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		s    *Session
+		want string
+	}{
+		{
+			name: "正常に二曲先のTrackのURIが返る",
+			s: &Session{
+				QueueTracks: []*QueueTrack{{URI: "0"}, {URI: "1"}, {URI: "2"}, {URI: "3"}},
+				QueueHead:   0,
+				StateType:   Play,
+			},
+			want: "2",
+		},
+		{
+			name: "二曲先の曲が存在しない時には空文字列が返る",
+			s: &Session{
+				QueueTracks: []*QueueTrack{{URI: "0"}, {URI: "1"}, {URI: "2"}, {URI: "3"}},
+				QueueHead:   2,
+				StateType:   Play,
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			got := tt.s.TrackURIShouldBeAddedWhenHandleTrackEnd()
+
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("TrackURIShouldBeAddedWhenHandleTrackEnd() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/domain/entity/session_test.go
+++ b/domain/entity/session_test.go
@@ -377,23 +377,13 @@ func TestSession_TrackURIsShouldBeAddedWhenStopToPlay(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "キューに4曲追加して、まだ再生を始めていない時は長さ2のスライス",
+			name: "キューに4曲追加して、まだ再生を始めていない時は長さ3のスライス",
 			s: &Session{
 				QueueTracks: []*QueueTrack{{URI: "0"}, {URI: "1"}, {URI: "2"}, {URI: "3"}},
 				QueueHead:   0,
 				StateType:   Stop,
 			},
-			want:    []string{"0", "1"},
-			wantErr: false,
-		},
-		{
-			name: "キューに4曲追加して、まだ再生を始めていない時は長さ2のスライス",
-			s: &Session{
-				QueueTracks: []*QueueTrack{{URI: "0"}, {URI: "1"}, {URI: "2"}, {URI: "3"}},
-				QueueHead:   0,
-				StateType:   Stop,
-			},
-			want:    []string{"0", "1"},
+			want:    []string{"0", "1", "2"},
 			wantErr: false,
 		},
 	}

--- a/domain/mock_spotify/player.go
+++ b/domain/mock_spotify/player.go
@@ -92,17 +92,17 @@ func (mr *MockPlayerMockRecorder) Pause(ctx, deviceID interface{}) *gomock.Call 
 }
 
 // AddToQueue mocks base method
-func (m *MockPlayer) AddToQueue(ctx context.Context, trackID, deviceID string) error {
+func (m *MockPlayer) AddToQueue(ctx context.Context, trackURI, deviceID string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddToQueue", ctx, trackID, deviceID)
+	ret := m.ctrl.Call(m, "AddToQueue", ctx, trackURI, deviceID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddToQueue indicates an expected call of AddToQueue
-func (mr *MockPlayerMockRecorder) AddToQueue(ctx, trackID, deviceID interface{}) *gomock.Call {
+func (mr *MockPlayerMockRecorder) AddToQueue(ctx, trackURI, deviceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToQueue", reflect.TypeOf((*MockPlayer)(nil).AddToQueue), ctx, trackID, deviceID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddToQueue", reflect.TypeOf((*MockPlayer)(nil).AddToQueue), ctx, trackURI, deviceID)
 }
 
 // SetRepeatMode mocks base method
@@ -131,4 +131,18 @@ func (m *MockPlayer) SetShuffleMode(ctx context.Context, on bool, deviceID strin
 func (mr *MockPlayerMockRecorder) SetShuffleMode(ctx, on, deviceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShuffleMode", reflect.TypeOf((*MockPlayer)(nil).SetShuffleMode), ctx, on, deviceID)
+}
+
+// SkipAllTracks mocks base method
+func (m *MockPlayer) SkipAllTracks(ctx context.Context, deviceID, trackURI string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SkipAllTracks", ctx, deviceID, trackURI)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SkipAllTracks indicates an expected call of SkipAllTracks
+func (mr *MockPlayerMockRecorder) SkipAllTracks(ctx, deviceID, trackURI interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SkipAllTracks", reflect.TypeOf((*MockPlayer)(nil).SkipAllTracks), ctx, deviceID, trackURI)
 }

--- a/domain/spotify/player.go
+++ b/domain/spotify/player.go
@@ -17,4 +17,5 @@ type Player interface {
 	AddToQueue(ctx context.Context, trackURI string, deviceID string) error
 	SetRepeatMode(ctx context.Context, on bool, deviceID string) error
 	SetShuffleMode(ctx context.Context, on bool, deviceID string) error
+	SkipAllTracks(ctx context.Context, deviceID string, trackURI string) error
 }

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -65,9 +65,7 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 
 	skipOnceTime := 3
 	sleepTime := 250 * time.Millisecond
-	j := 0
 	for i := 1; ; i++ {
-		j = j + 1
 		err := cli.NextOpt(opt)
 		// SpotifyAPIを叩いてからSpotifyが曲をskipするのに時間がかかるため余計にAPIを叩かないように調節
 		if convErr := c.convertPlayerError(err); convErr != nil {
@@ -86,10 +84,6 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 			}
 		}
 	}
-	logger := log.New()
-	logger.Infoj(map[string]interface{}{
-		"message": j,
-	})
 	return nil
 }
 

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -64,7 +64,7 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 	}
 
 	skipOnceTime := 3
-	sleepTime := 500 * time.Millisecond
+	sleepTime := 250 * time.Millisecond
 	for i := 1; ; i++ {
 		err := cli.NextOpt(opt)
 		// SpotifyAPIを叩いてからSpotifyが曲をskipするのに時間がかかるため余計にAPIを叩かないように調節

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -67,8 +67,6 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 	skipOnceTime := 3
 	var sleepTime time.Duration = 500
 	isTracksOnQueue := true
-	//TODO: あとで消す
-	logger.Infoj(map[string]interface{}{"message": "start loop on skipAllTracks"})
 	for i := 1; i <= skipOnceTime && isTracksOnQueue; i++ {
 		switch i {
 		case skipOnceTime:
@@ -89,8 +87,6 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 			}
 		}
 	}
-	//TODO: あとで消す
-	logger.Infoj(map[string]interface{}{"message": "finish loop on skipAllTracks"})
 	return nil
 }
 

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -66,24 +66,21 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 	skipOnceTime := 3
 	sleepTime := 500 * time.Millisecond
 	isTracksOnQueue := true
-	for i := 1; i <= skipOnceTime && isTracksOnQueue; i++ {
-		switch i {
-		case skipOnceTime:
+	for i := 1; isTracksOnQueue; i++ {
+		if skipOnceTime == i {
 			cpi, err := c.CurrentlyPlaying(ctx)
 			if err != nil {
 				return fmt.Errorf("spotify api: CurrentlyPlaying: %w", err)
 			}
 			isTracksOnQueue = cpi.Playing
 			i = 1
-			fallthrough
+		}
 
-		default:
-			err := cli.NextOpt(opt)
-			// SpotifyAPIを叩いてからSpotifyが曲をskipするのに時間がかかるため余計にAPIを叩かないように調節
-			time.Sleep(sleepTime)
-			if convErr := c.convertPlayerError(err); convErr != nil {
-				return fmt.Errorf("spotify api: next: %w", convErr)
-			}
+		err := cli.NextOpt(opt)
+		// SpotifyAPIを叩いてからSpotifyが曲をskipするのに時間がかかるため余計にAPIを叩かないように調節
+		time.Sleep(sleepTime)
+		if convErr := c.convertPlayerError(err); convErr != nil {
+			return fmt.Errorf("spotify api: next: %w", convErr)
 		}
 	}
 	return nil

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -46,7 +46,6 @@ func (c *Client) toDevice(device spotify.PlayerDevice) *entity.Device {
 // skipAllTracks はユーザーのSpotifyに積まれている「次に再生される曲」「再生待ち」を全てskipします。
 // プレミアム会員必須
 func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI string) error {
-	logger := log.New()
 	token, ok := service.GetTokenFromContext(ctx)
 	if !ok {
 		return errors.New("token not found")

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -64,7 +64,7 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 	}
 
 	skipOnceTime := 3
-	sleepTime := 250 * time.Millisecond
+	sleepTime := 300 * time.Millisecond
 	for i := 1; ; i++ {
 		err := cli.NextOpt(opt)
 		// SpotifyAPIを叩いてからSpotifyが曲をskipするのに時間がかかるため余計にAPIを叩かないように調節

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -66,6 +66,13 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 	skipOnceTime := 3
 	sleepTime := 500 * time.Millisecond
 	for i := 1; ; i++ {
+		err := cli.NextOpt(opt)
+		// SpotifyAPIを叩いてからSpotifyが曲をskipするのに時間がかかるため余計にAPIを叩かないように調節
+		time.Sleep(sleepTime)
+		if convErr := c.convertPlayerError(err); convErr != nil {
+			return fmt.Errorf("spotify api: next: %w", convErr)
+		}
+
 		if skipOnceTime == i {
 			cpi, err := c.CurrentlyPlaying(ctx)
 			if err != nil {
@@ -77,13 +84,6 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 			} else {
 				i = 1
 			}
-		}
-
-		err := cli.NextOpt(opt)
-		// SpotifyAPIを叩いてからSpotifyが曲をskipするのに時間がかかるため余計にAPIを叩かないように調節
-		time.Sleep(sleepTime)
-		if convErr := c.convertPlayerError(err); convErr != nil {
-			return fmt.Errorf("spotify api: next: %w", convErr)
 		}
 	}
 	return nil

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -73,7 +73,7 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 			return fmt.Errorf("spotify api: next: %w", convErr)
 		}
 
-		if skipOnceTime == i {
+		if i%skipOnceTime == 0 {
 			cpi, err := c.CurrentlyPlaying(ctx)
 			if err != nil {
 				return fmt.Errorf("spotify api: CurrentlyPlaying: %w", err)
@@ -81,8 +81,6 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 
 			if !cpi.Playing {
 				break
-			} else {
-				i = 1
 			}
 		}
 	}

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -72,7 +72,7 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 				return fmt.Errorf("spotify api: CurrentlyPlaying: %w", err)
 			}
 
-			if cpi.Playing {
+			if !cpi.Playing {
 				break
 			} else {
 				i = 1

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -65,15 +65,18 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 
 	skipOnceTime := 3
 	sleepTime := 500 * time.Millisecond
-	isTracksOnQueue := true
-	for i := 1; isTracksOnQueue; i++ {
+	for i := 1; ; i++ {
 		if skipOnceTime == i {
 			cpi, err := c.CurrentlyPlaying(ctx)
 			if err != nil {
 				return fmt.Errorf("spotify api: CurrentlyPlaying: %w", err)
 			}
-			isTracksOnQueue = cpi.Playing
-			i = 1
+
+			if cpi.Playing {
+				break
+			} else {
+				i = 1
+			}
 		}
 
 		err := cli.NextOpt(opt)

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -65,15 +65,17 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 
 	skipOnceTime := 3
 	sleepTime := 250 * time.Millisecond
+	j := 0
 	for i := 1; ; i++ {
+		j = j + 1
 		err := cli.NextOpt(opt)
 		// SpotifyAPIを叩いてからSpotifyが曲をskipするのに時間がかかるため余計にAPIを叩かないように調節
-		time.Sleep(sleepTime)
 		if convErr := c.convertPlayerError(err); convErr != nil {
 			return fmt.Errorf("spotify api: next: %w", convErr)
 		}
 
 		if i%skipOnceTime == 0 {
+			time.Sleep(sleepTime)
 			cpi, err := c.CurrentlyPlaying(ctx)
 			if err != nil {
 				return fmt.Errorf("spotify api: CurrentlyPlaying: %w", err)
@@ -84,6 +86,10 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 			}
 		}
 	}
+	logger := log.New()
+	logger.Infoj(map[string]interface{}{
+		"message": j,
+	})
 	return nil
 }
 

--- a/spotify/player.go
+++ b/spotify/player.go
@@ -64,7 +64,7 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 	}
 
 	skipOnceTime := 3
-	var sleepTime time.Duration = 500
+	sleepTime := 500 * time.Millisecond
 	isTracksOnQueue := true
 	for i := 1; i <= skipOnceTime && isTracksOnQueue; i++ {
 		switch i {
@@ -80,7 +80,7 @@ func (c *Client) SkipAllTracks(ctx context.Context, deviceID string, trackURI st
 		default:
 			err := cli.NextOpt(opt)
 			// SpotifyAPIを叩いてからSpotifyが曲をskipするのに時間がかかるため余計にAPIを叩かないように調節
-			time.Sleep(time.Millisecond * sleepTime)
+			time.Sleep(sleepTime)
 			if convErr := c.convertPlayerError(err); convErr != nil {
 				return fmt.Errorf("spotify api: next: %w", convErr)
 			}

--- a/spotify/player_test.go
+++ b/spotify/player_test.go
@@ -193,3 +193,36 @@ func TestClient_SetRepeatMode(t *testing.T) {
 		})
 	}
 }
+
+// テスト前にSpotify側で「次に再生される曲」を積んでください
+func TestClient_SkipAllTracks(t *testing.T) {
+	tests := []struct {
+		name    string
+		wantErr string
+	}{
+		{
+			name:    "正常に動作する",
+			wantErr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient(config.NewSpotify())
+			token := &oauth2.Token{
+				AccessToken:  "",
+				TokenType:    "Bearer",
+				RefreshToken: os.Getenv("SPOTIFY_REFRESH_TOKEN_FOR_TEST"),
+				Expiry:       time.Now(),
+			}
+			token, err := c.Refresh(token)
+			if err != nil {
+				t.Fatal(err)
+			}
+			ctx := context.Background()
+			ctx = service.SetTokenToContext(ctx, token)
+			if err := c.SkipAllTracks(ctx); err.Error() != tt.wantErr {
+				t.Errorf("SkipAllTracks() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -152,7 +152,7 @@ func (s *SessionUseCase) stopToPlay(ctx context.Context, sess *entity.Session) e
 		return fmt.Errorf(": %w", err)
 	}
 
-	if err := s.playerCli.SkipAllTracks(ctx, sess.DeviceID, sess.QueueTracks[0].URI); err != nil {
+	if err := s.playerCli.SkipAllTracks(ctx, sess.DeviceID, trackURIs[0]); err != nil {
 		return fmt.Errorf("call SkipAllTracks: %w", err)
 	}
 	for i := 0; i < len(trackURIs); i++ {

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -120,7 +120,7 @@ func TestSessionHandler_Playback(t *testing.T) {
 				m.EXPECT().SkipAllTracks(gomock.Any(), "device_id", "spotify:track:5uQ0vKy2973Y9IUCd1wMEF").Return(nil)
 				m.EXPECT().PlayWithTracks(gomock.Any(), "device_id", []string{"spotify:track:5uQ0vKy2973Y9IUCd1wMEF"}).Return(nil)
 				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:49BRCNV7E94s7Q2FUhhT3w", "device_id").Return(nil)
-				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:shouldUnuseInThisTestURI", "device_id").Return(nil)
+				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:3", "device_id").Return(nil)
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockPusherFn: func(m *mock_event.MockPusher) {
@@ -140,7 +140,7 @@ func TestSessionHandler_Playback(t *testing.T) {
 					QueueTracks: []*entity.QueueTrack{
 						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
 						{Index: 1, URI: "spotify:track:49BRCNV7E94s7Q2FUhhT3w"},
-						{Index: 2, URI: "spotify:track:shouldUnuseInThisTestURI"},
+						{Index: 2, URI: "spotify:track:3"},
 					},
 				}, nil)
 				m.EXPECT().Update(&entity.Session{
@@ -153,7 +153,7 @@ func TestSessionHandler_Playback(t *testing.T) {
 					QueueTracks: []*entity.QueueTrack{
 						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
 						{Index: 1, URI: "spotify:track:49BRCNV7E94s7Q2FUhhT3w"},
-						{Index: 2, URI: "spotify:track:shouldUnuseInThisTestURI"},
+						{Index: 2, URI: "spotify:track:3"},
 					},
 				}).Return(nil)
 			},

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -111,15 +111,14 @@ func TestSessionHandler_Playback(t *testing.T) {
 			wantCode: http.StatusBadRequest,
 		},
 		{
-			name:      "PLAYでStateTypeがSTOPのときは全てのキューと一緒に再生をし始めて202",
+			name:      "PLAYでStateTypeがSTOPのときは1曲を再生し次の1曲のみSpotifyのqueueに追加し、再生を始めて202",
 			sessionID: "sessionID",
 			body:      `{"state": "PLAY"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
 				m.EXPECT().SetRepeatMode(gomock.Any(), false, "device_id").Return(nil)
 				m.EXPECT().SetShuffleMode(gomock.Any(), false, "device_id").Return(nil)
 				m.EXPECT().SkipAllTracks(gomock.Any(), "device_id", "spotify:track:5uQ0vKy2973Y9IUCd1wMEF").Return(nil)
-				m.EXPECT().PlayWithTracks(gomock.Any(), "device_id",
-					[]string{"spotify:track:5uQ0vKy2973Y9IUCd1wMEF"}).Return(nil)
+				m.EXPECT().PlayWithTracks(gomock.Any(), "device_id", []string{"spotify:track:5uQ0vKy2973Y9IUCd1wMEF"}).Return(nil)
 				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:49BRCNV7E94s7Q2FUhhT3w", "device_id").Return(nil)
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
@@ -140,6 +139,7 @@ func TestSessionHandler_Playback(t *testing.T) {
 					QueueTracks: []*entity.QueueTrack{
 						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
 						{Index: 1, URI: "spotify:track:49BRCNV7E94s7Q2FUhhT3w"},
+						{Index: 2, URI: "spotify:track:shouldUnuseInThisTestURI"},
 					},
 				}, nil)
 				m.EXPECT().Update(&entity.Session{
@@ -152,6 +152,7 @@ func TestSessionHandler_Playback(t *testing.T) {
 					QueueTracks: []*entity.QueueTrack{
 						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
 						{Index: 1, URI: "spotify:track:49BRCNV7E94s7Q2FUhhT3w"},
+						{Index: 2, URI: "spotify:track:shouldUnuseInThisTestURI"},
 					},
 				}).Return(nil)
 			},
@@ -586,6 +587,31 @@ func TestSessionHandler_AddQueue(t *testing.T) {
 		},
 		},
 	}
+	sessionHadManyTracks := &entity.Session{
+		ID:        "sessionHadManyTracksID",
+		Name:      "sessionName",
+		CreatorID: "sessionCreator",
+		DeviceID:  "sessionDeviceID",
+		StateType: "PLAY",
+		QueueHead: 0,
+		QueueTracks: []*entity.QueueTrack{
+			{
+				Index:     0,
+				URI:       "spotify:track:track_uri1",
+				SessionID: "sessionID",
+			},
+			{
+				Index:     1,
+				URI:       "spotify:track:track_uri2",
+				SessionID: "sessionID",
+			},
+			{
+				Index:     2,
+				URI:       "spotify:track:track_uri3",
+				SessionID: "sessionID",
+			},
+		},
+	}
 	tests := []struct {
 		name                     string
 		sessionID                string
@@ -598,7 +624,29 @@ func TestSessionHandler_AddQueue(t *testing.T) {
 		wantCode                 int
 	}{
 		{
-			name:      "正しいuriが渡されると正常に動作する",
+			name:                "正しくuriが渡されると正常に動作し、sessionがqueueの最後から二番目以内の曲を再生している場合はAddToQueueを叩く",
+			sessionID:           "sessionHadManyTracksID",
+			body:                `{"uri": "spotify:track:valid_uri"}`,
+			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {},
+			prepareMockPusherFn: func(m *mock_event.MockPusher) {
+				m.EXPECT().Push(&event.PushMessage{
+					SessionID: "sessionHadManyTracksID",
+					Msg:       entity.EventAddTrack,
+				})
+			},
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
+				m.EXPECT().FindByID("sessionHadManyTracksID").Return(sessionHadManyTracks, nil)
+				m.EXPECT().StoreQueueTrack(&entity.QueueTrackToStore{
+					URI:       "spotify:track:valid_uri",
+					SessionID: "sessionHadManyTracksID",
+				}).Return(nil)
+			},
+			wantErr:  false,
+			wantCode: http.StatusNoContent,
+		},
+		{
+			name:      "正しいuriが渡されると正常に動作し、sessionがqueueの最後から二番目以内ではない曲を再生している場合はAddToQueueを叩かない",
 			sessionID: "sessionID",
 			body:      `{"uri": "spotify:track:valid_uri"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -117,6 +117,7 @@ func TestSessionHandler_Playback(t *testing.T) {
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
 				m.EXPECT().SetRepeatMode(gomock.Any(), false, "device_id").Return(nil)
 				m.EXPECT().SetShuffleMode(gomock.Any(), false, "device_id").Return(nil)
+				m.EXPECT().SkipAllTracks(gomock.Any(), "device_id", "spotify:track:5uQ0vKy2973Y9IUCd1wMEF").Return(nil)
 				m.EXPECT().PlayWithTracks(gomock.Any(), "device_id",
 					[]string{"spotify:track:5uQ0vKy2973Y9IUCd1wMEF"}).Return(nil)
 				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:49BRCNV7E94s7Q2FUhhT3w", "device_id").Return(nil)
@@ -585,7 +586,6 @@ func TestSessionHandler_AddQueue(t *testing.T) {
 		},
 		},
 	}
-
 	tests := []struct {
 		name                     string
 		sessionID                string

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -120,6 +120,7 @@ func TestSessionHandler_Playback(t *testing.T) {
 				m.EXPECT().SkipAllTracks(gomock.Any(), "device_id", "spotify:track:5uQ0vKy2973Y9IUCd1wMEF").Return(nil)
 				m.EXPECT().PlayWithTracks(gomock.Any(), "device_id", []string{"spotify:track:5uQ0vKy2973Y9IUCd1wMEF"}).Return(nil)
 				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:49BRCNV7E94s7Q2FUhhT3w", "device_id").Return(nil)
+				m.EXPECT().AddToQueue(gomock.Any(), "spotify:track:shouldUnuseInThisTestURI", "device_id").Return(nil)
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockPusherFn: func(m *mock_event.MockPusher) {

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -625,7 +625,7 @@ func TestSessionHandler_AddQueue(t *testing.T) {
 		wantCode                 int
 	}{
 		{
-			name:                "正しくuriが渡されると正常に動作し、sessionがqueueの最後から二番目以内の曲を再生している場合はAddToQueueを叩く",
+			name:                "正しいuriが渡されると正常に動作し、sessionがqueueの最後から二番目以内ではない曲を再生している場合はAddToQueueを叩かない",
 			sessionID:           "sessionHadManyTracksID",
 			body:                `{"uri": "spotify:track:valid_uri"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {},
@@ -647,7 +647,7 @@ func TestSessionHandler_AddQueue(t *testing.T) {
 			wantCode: http.StatusNoContent,
 		},
 		{
-			name:      "正しいuriが渡されると正常に動作し、sessionがqueueの最後から二番目以内ではない曲を再生している場合はAddToQueueを叩かない",
+			name:      "正しくuriが渡されると正常に動作し、sessionがqueueの最後から二番目以内の曲を再生している場合はAddToQueueを叩く",
 			sessionID: "sessionID",
 			body:      `{"uri": "spotify:track:valid_uri"}`,
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {


### PR DESCRIPTION
## Related Issue
#125 #86 

## What

- skipのAPIを使用して「次に再生される曲」を飛ばす
- playWithTracksで「再生待ち」をリセットできることを利用してダミーの曲をplayWithTracksして「再生待ち」を0曲にする
- 「次に再生される曲」が溜まっているとskipに時間がかかるためRelaymが「次に再生される曲」にためる曲数を常に最大2曲にする（セッション開始前にユーザーが「次に再生される曲」に溜めてた場合はあんまり考えていない）


## Memo
通話してた時の僕「ん〜まあ1, 2時間で終わります!w」
今の僕「4時間ちょいかかったが…？」