### PR TITLE
gosecのエラーをなくす

### DIFF
--- a/spotify/track.go
+++ b/spotify/track.go
@@ -60,6 +60,7 @@ func (c *Client) toTracks(resultTracks []spotify.FullTrack) []*entity.Track {
 	tracks := make([]*entity.Track, len(resultTracks))
 
 	for i, rt := range resultTracks {
+		rt := rt
 		tracks[i] = c.toTrack(&rt)
 	}
 


### PR DESCRIPTION
## Related Issue

## Why

for rangeで回しているスライスのvalueのポインタを他の関数に渡すのはまずい。

やらかすとこういうバグを踏み抜くことになる。
https://blog.p1ass.com/posts/pointer-of-for-range-loop-of-go/

gosecはこういう危険なコードを検出してくれる静的解析ツール。
(GoLandならFile Watcherでgofmtと同じように設定できるのでオススメ)

```
/usr/local/bin/golangci-lint run --disable=typecheck --enable=gosec,prealloc,gocognit /Users/plus/ghq/github.com/camphor-/relaym-server/spotify
spotify/track.go:63:25: G601: Implicit memory aliasing in for loop. (gosec)
		tracks[i] = c.toTrack(&rt)
```

## What

- ループ内で再度変数を生成してバグる危険性をなくす

## Memo
<!-- レビュワーに伝えたいことがあれば -->