### PR TITLE
 セッション作成者からのリクエストのときのみ、PAUSE→PLAYでactive device not foundになっても再生処理を続行する

### DIFF
--- a/domain/service/auth.go
+++ b/domain/service/auth.go
@@ -10,8 +10,9 @@ import (
 type ContextKey string
 
 var (
-	userIDKey ContextKey = "userIDKey"
-	tokenKey  ContextKey = "tokenKey"
+	userIDKey    ContextKey = "userIDKey"
+	creatorIDKey ContextKey = "creatorIDKey"
+	tokenKey     ContextKey = "tokenKey"
 )
 
 // SetUserIDToContext はユーザIDをContextにセットします。
@@ -19,15 +20,26 @@ func SetUserIDToContext(ctx context.Context, userID string) context.Context {
 	return context.WithValue(ctx, userIDKey, userID)
 }
 
-// SetCreatorTokenToContext はトークンをContextにセットします。
+// SetCreatorIDToContext はセッション作成者のIDをContextにセットします。
+func SetCreatorIDToContext(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, creatorIDKey, userID)
+}
+
+// SetTokenToContext はトークンをContextにセットします。
 func SetTokenToContext(ctx context.Context, token *oauth2.Token) context.Context {
 	return context.WithValue(ctx, tokenKey, token)
-
 }
 
 // GetUserIDFromContext はContextからユーザIDを取得します。
 func GetUserIDFromContext(ctx context.Context) (string, bool) {
 	v := ctx.Value(userIDKey)
+	userID, ok := v.(string)
+	return userID, ok
+}
+
+// GetCreatorIDFromContext はContextからセッション作成者のIDを取得します。
+func GetCreatorIDFromContext(ctx context.Context) (string, bool) {
+	v := ctx.Value(creatorIDKey)
 	userID, ok := v.(string)
 	return userID, ok
 }

--- a/domain/service/auth_test.go
+++ b/domain/service/auth_test.go
@@ -45,6 +45,41 @@ func TestGetUserIDFromContext(t *testing.T) {
 	}
 }
 
+func TestGetCreatorIDFromContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		ctx   context.Context
+		want  string
+		want1 bool
+	}{
+		{
+			name:  "userIDがセットされているとき正しくuserIDを取得できる",
+			ctx:   SetCreatorIDToContext(context.Background(), "userID"),
+			want:  "userID",
+			want1: true,
+		},
+		{
+			name:  "userIDがセットされていないとfalseが帰る",
+			ctx:   context.Background(),
+			want:  "",
+			want1: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1 := GetCreatorIDFromContext(tt.ctx)
+			if got != tt.want {
+				t.Errorf("GetCreatorIDFromContext() got = %v, want %v", got, tt.want)
+			}
+			if got1 != tt.want1 {
+				t.Errorf("GetCreatorIDFromContext() got1 = %v, want %v", got1, tt.want1)
+			}
+		})
+	}
+}
+
 func TestGetTokenFromContext(t *testing.T) {
 	t.Parallel()
 

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -110,8 +110,8 @@ func (s *SessionUseCase) playORResume(ctx context.Context, sessionID string) err
 		return fmt.Errorf("find session id=%s: %w", sessionID, err)
 	}
 
-	// active device not foundになった場合、スマホ側でSpotifyアプリを強制的に開かせてactiveにするので、
-	// err != nilだけど正常処理を行う。
+	// active device not foundになった場合、スマホ側でSpotifyアプリを強制的に開かせてactiveにするので、正常処理をする。
+	// その処理を切り替えるフラグとして使う。
 	var returnErr error
 
 	userID, _ := service.GetUserIDFromContext(ctx)

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -382,17 +382,13 @@ func (s *SessionUseCase) handleInterrupt(sess *entity.Session) error {
 
 // SetDevice は指定されたidのセッションの作成者と再生する端末を紐付けて再生するデバイスを指定します。
 func (s *SessionUseCase) SetDevice(ctx context.Context, sessionID string, deviceID string) error {
-	userID, ok := service.GetUserIDFromContext(ctx)
-	if !ok {
-		return errors.New("get user id from context")
-	}
-
 	sess, err := s.sessionRepo.FindByID(sessionID)
 	if err != nil {
 		return fmt.Errorf("find session id=%s: %w", sessionID, err)
 	}
 
-	if !sess.IsCreator(userID) {
+	userID, ok := service.GetUserIDFromContext(ctx)
+	if !ok || !sess.IsCreator(userID) {
 		return fmt.Errorf("userID=%s creatorID=%s: %w", userID, sess.CreatorID, entity.ErrUserIsNotSessionCreator)
 	}
 

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -389,11 +389,6 @@ func (s *SessionUseCase) SetDevice(ctx context.Context, sessionID string, device
 		return fmt.Errorf("find session id=%s: %w", sessionID, err)
 	}
 
-	userID, ok := service.GetUserIDFromContext(ctx)
-	if !ok || !sess.IsCreator(userID) {
-		return fmt.Errorf("userID=%s creatorID=%s: %w", userID, sess.CreatorID, entity.ErrUserIsNotSessionCreator)
-	}
-
 	sess.DeviceID = deviceID
 	if err := s.sessionRepo.Update(sess); err != nil {
 		return fmt.Errorf("update device id: device_id=%s session_id=%s: %w", deviceID, sess.ID, err)

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -114,15 +114,17 @@ func (s *SessionUseCase) playORResume(ctx context.Context, sessionID string) err
 	// err != nilだけど正常処理を行う。
 	var returnErr error
 
+	userID, _ := service.GetUserIDFromContext(ctx)
+
 	err = s.playerCli.SetRepeatMode(ctx, false, sess.DeviceID)
-	if errors.Is(err, entity.ErrActiveDeviceNotFound) {
+	if errors.Is(err, entity.ErrActiveDeviceNotFound) && sess.IsCreator(userID) {
 		returnErr = err
 	} else if err != nil {
 		return fmt.Errorf("call set repeat off api: %w", err)
 	}
 
 	err = s.playerCli.SetShuffleMode(ctx, false, sess.DeviceID)
-	if errors.Is(err, entity.ErrActiveDeviceNotFound) {
+	if errors.Is(err, entity.ErrActiveDeviceNotFound) && sess.IsCreator(userID) {
 		returnErr = err
 	} else if err != nil {
 		return fmt.Errorf("call set repeat off api: %w", err)
@@ -130,7 +132,7 @@ func (s *SessionUseCase) playORResume(ctx context.Context, sessionID string) err
 
 	if sess.IsResume(entity.Play) {
 		err := s.playerCli.Play(ctx, sess.DeviceID)
-		if errors.Is(err, entity.ErrActiveDeviceNotFound) {
+		if errors.Is(err, entity.ErrActiveDeviceNotFound) && sess.IsCreator(userID) {
 			returnErr = err
 		} else if err != nil {
 			return fmt.Errorf("call play api: %w", err)

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -69,10 +69,6 @@ func TestSessionHandler_Playback(t *testing.T) {
 				m.EXPECT().Play(gomock.Any(), "device_id").Return(nil)
 			},
 			prepareMockPusherFn: func(m *mock_event.MockPusher) {
-				m.EXPECT().Push(&event.PushMessage{
-					SessionID: "sessionID",
-					Msg:       entity.EventPlay,
-				})
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -440,26 +440,6 @@ func TestSessionHandler_SetDevice(t *testing.T) {
 			wantCode:              http.StatusNotFound,
 		},
 		{
-			name:      "リクエストしたユーザがセッションの作成者ではないと403",
-			userID:    "user_id",
-			sessionID: "session_id",
-			body:      `{"device_id": "device_id"}`,
-			prepareMockRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("session_id").Return(&entity.Session{
-					ID:          "session_id",
-					Name:        "name",
-					CreatorID:   "creator_id",
-					QueueHead:   0,
-					DeviceID:    "device_id",
-					StateType:   "PAUSE",
-					QueueTracks: nil,
-				}, nil)
-			},
-			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
-			wantErr:               true,
-			wantCode:              http.StatusForbidden,
-		},
-		{
 			name:      "正しくデバイスをセットできると204",
 			userID:    "creator_id",
 			sessionID: "session_id",

--- a/web/sessionToken_middleware.go
+++ b/web/sessionToken_middleware.go
@@ -4,7 +4,10 @@ import (
 	"errors"
 	"net/http"
 
+	"golang.org/x/oauth2"
+
 	"github.com/camphor-/relaym-server/domain/entity"
+	"github.com/camphor-/relaym-server/domain/service"
 	"github.com/camphor-/relaym-server/log"
 	"github.com/camphor-/relaym-server/usecase"
 
@@ -48,7 +51,14 @@ func (m *CreatorTokenMiddleware) SetCreatorTokenToContext(next echo.HandlerFunc)
 		}
 		token = newToken
 
-		c = setToContext(c, creatorID, token)
+		c = setToCreatorContext(c, creatorID, token)
 		return next(c)
 	}
+}
+func setToCreatorContext(c echo.Context, userID string, token *oauth2.Token) echo.Context {
+	ctx := c.Request().Context()
+	ctx = service.SetCreatorIDToContext(ctx, userID)
+	ctx = service.SetTokenToContext(ctx, token)
+	c.SetRequest(c.Request().WithContext(ctx))
+	return c
 }

--- a/web/sessionToken_middleware_test.go
+++ b/web/sessionToken_middleware_test.go
@@ -67,7 +67,7 @@ func TestSessionTokenMiddleware_SetTokenToContext(t *testing.T) {
 			prepareAuthRepo: func(r *mock_repository.MockAuth) {},
 			prepareAuthCli:  func(c *mock_spotify.MockAuth) {},
 			next: func(c echo.Context) error {
-				userID, ok := service.GetUserIDFromContext(c.Request().Context())
+				userID, ok := service.GetCreatorIDFromContext(c.Request().Context())
 				if !ok {
 					t.Errorf("CreatorTokenMiddleware.SetCreatorTokenToContext() userID not found in context")
 				}
@@ -126,7 +126,7 @@ func TestSessionTokenMiddleware_SetTokenToContext(t *testing.T) {
 				}, nil)
 			},
 			next: func(c echo.Context) error {
-				userID, ok := service.GetUserIDFromContext(c.Request().Context())
+				userID, ok := service.GetCreatorIDFromContext(c.Request().Context())
 				if !ok {
 					t.Errorf("CreatorTokenMiddleware.SetCreatorTokenToContext() userID not found in context")
 				}


### PR DESCRIPTION
## Related Issue

#128 

## What

- ログインユーザの情報は Contextの userID に、セッション作成者のIDは creatorIDにセットする
-  セッション作成者からのリクエストのときのみ、PAUSE→PLAYでactive device not foundになっても再生処理を続行する
- 

## Memo
<!-- レビュワーに伝えたいことがあれば -->