### PR TITLE
「再生するデバイスがオフラインかつセッション作成者のリクエストのときは403を返しつつも再生処理を行う」仕様を消す

### DIFF
--- a/web/handler/session_state_test.go
+++ b/web/handler/session_state_test.go
@@ -127,48 +127,6 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			wantCode: http.StatusAccepted,
 		},
 		{
-			// https://github.com/camphor-/relaym-client/issues/195
-			name:      "StateType=Pause: 再生するデバイスがオフラインかつセッション作成者のリクエストのときは403を返しつつも再生処理を行う",
-			sessionID: "sessionID",
-			userID:    "creator_id",
-			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
-				m.EXPECT().SetRepeatMode(gomock.Any(), false, "device_id").Return(entity.ErrActiveDeviceNotFound)
-				m.EXPECT().SetShuffleMode(gomock.Any(), false, "device_id").Return(entity.ErrActiveDeviceNotFound)
-				m.EXPECT().Play(gomock.Any(), "device_id").Return(nil)
-			},
-			prepareMockPusherFn: func(m *mock_event.MockPusher) {
-			},
-			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
-			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
-					ID:        "sessionID",
-					Name:      "session_name",
-					CreatorID: "creator_id",
-					QueueHead: 0,
-					DeviceID:  "device_id",
-					StateType: entity.Pause,
-					QueueTracks: []*entity.QueueTrack{
-						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
-						{Index: 1, URI: "spotify:track:49BRCNV7E94s7Q2FUhhT3w"},
-					},
-				}, nil)
-				m.EXPECT().Update(&entity.Session{
-					ID:        "sessionID",
-					Name:      "session_name",
-					CreatorID: "creator_id",
-					QueueHead: 0,
-					DeviceID:  "device_id",
-					StateType: "PLAY",
-					QueueTracks: []*entity.QueueTrack{
-						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
-						{Index: 1, URI: "spotify:track:49BRCNV7E94s7Q2FUhhT3w"},
-					},
-				}).Return(nil)
-			},
-			wantErr:  true,
-			wantCode: http.StatusForbidden,
-		},
-		{
 			name:      "StateType=PAUSE: 再生するデバイスがオフラインかつセッション作成者以外のリクエストのとき403",
 			sessionID: "sessionID",
 			userID:    "nonCreatorID",


### PR DESCRIPTION
## Related Issue
#128

## What

- クライアント側でダイアログを出すことになったので消す

https://github.com/camphor-/relaym-client/issues/195#issuecomment-662820351

## Memo
<!-- レビュワーに伝えたいことがあれば -->