### PR TITLE
[WIP] タイミングが悪いとget sessionsでInterruptする

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 
+	"github.com/camphor-/relaym-server/domain/entity"
+
 	"os"
 	"os/signal"
 	"time"
@@ -42,9 +44,11 @@ func main() {
 	userRepo := database.NewUserRepository(dbMap)
 	sessionRepo := database.NewSessionRepository(dbMap)
 
+	syncCheckTimerManager := entity.NewSyncCheckTimerManager()
+
 	userUC := usecase.NewUserUseCase(spotifyCli, userRepo)
 	authUC := usecase.NewAuthUseCase(spotifyCli, spotifyCli, authRepo, userRepo, sessionRepo)
-	sessionTimerUC := usecase.NewSessionTimerUseCase(sessionRepo, spotifyCli, hub)
+	sessionTimerUC := usecase.NewSessionTimerUseCase(sessionRepo, spotifyCli, hub, syncCheckTimerManager)
 	sessionUC := usecase.NewSessionUseCase(sessionRepo, userRepo, spotifyCli, spotifyCli, spotifyCli, hub, sessionTimerUC)
 	sessionStateUC := usecase.NewSessionStateUseCase(sessionRepo, spotifyCli, hub, sessionTimerUC)
 	trackUC := usecase.NewTrackUseCase(spotifyCli)

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -141,18 +141,22 @@ func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*ent
 		return nil, nil, nil, fmt.Errorf("CurrentlyPlaying: %w", err)
 	}
 
-	if err := session.IsPlayingCorrectTrack(cpi); err != nil {
-		s.timerUC.deleteTimer(session.ID)
-		if interErr := s.timerUC.handleInterrupt(session); interErr != nil {
-			return nil, nil, nil, fmt.Errorf("check whether playing correct track: handle interrupt: %v: %w", interErr, err)
-		}
+	// timerが存在しない時はsyncCheckOffsetの時間なのでcpiのチェックは飛ばす
+	if _, isExist := s.timerUC.tm.GetTimer(sessionID); isExist {
+		if err := session.IsPlayingCorrectTrack(cpi); err != nil {
+			s.timerUC.deleteTimer(session.ID)
+			if interErr := s.timerUC.handleInterrupt(session); interErr != nil {
+				return nil, nil, nil, fmt.Errorf("check whether playing correct track: handle interrupt: %v: %w", interErr, err)
+			}
 
-		if updateErr := s.sessionRepo.Update(session); updateErr != nil {
-			return nil, nil, nil, fmt.Errorf("update session id=%s: %v: %w", session.ID, err, updateErr)
-		}
+			if updateErr := s.sessionRepo.Update(session); updateErr != nil {
+				return nil, nil, nil, fmt.Errorf("update session id=%s: %v: %w", session.ID, err, updateErr)
+			}
 
-		return entity.NewSessionWithUser(session, creator), tracks, cpi, nil
+			return entity.NewSessionWithUser(session, creator), tracks, cpi, nil
+		}
 	}
+
 	return entity.NewSessionWithUser(session, creator), tracks, cpi, nil
 }
 

--- a/usecase/session_test.go
+++ b/usecase/session_test.go
@@ -28,14 +28,15 @@ func TestSessionUseCase_CanConnectToPusher(t *testing.T) {
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID("not_found_session_id").Return(nil, entity.ErrSessionNotFound)
 			},
-			wantErr: true,
+			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {},
+			wantErr:             true,
 		},
 		{
 			name:      "StateがStopのセッションのとき正しくWebSocketのコネクションが確立される",
 			sessionID: "sessionID",
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
-					ID:          "sessionID1",
+					ID:          "sessionID",
 					Name:        "session_name",
 					CreatorID:   "creator_id",
 					QueueHead:   0,
@@ -75,7 +76,7 @@ func TestSessionUseCase_CanConnectToPusher(t *testing.T) {
 			sessionID: "sessionID",
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
-					ID:        "sessionID2",
+					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
 					QueueHead: 0,
@@ -121,10 +122,10 @@ func TestSessionUseCase_CanConnectToPusher(t *testing.T) {
 			mockSessionRepo := mock_repository.NewMockSession(ctrl)
 			tt.prepareMockSessionRepoFn(mockSessionRepo)
 			mockPlayer := mock_spotify.NewMockPlayer(ctrl)
-			tt.prepareMockSessionRepoFn(mockSessionRepo)
+			tt.prepareMockPlayerFn(mockPlayer)
 			syncCheckTimerManager := entity.NewSyncCheckTimerManager()
 			stUC := NewSessionTimerUseCase(nil, mockPlayer, nil, syncCheckTimerManager)
-			s := NewSessionUseCase(mockSessionRepo, nil, nil, nil, nil, nil, stUC)
+			s := NewSessionUseCase(mockSessionRepo, nil, mockPlayer, nil, nil, nil, stUC)
 
 			if err := s.CanConnectToPusher(context.Background(), tt.sessionID); (err != nil) != tt.wantErr {
 				t.Errorf("CanConnectToPusher() error = %v, wantErr %v", err, tt.wantErr)

--- a/usecase/session_timer_test.go
+++ b/usecase/session_timer_test.go
@@ -459,7 +459,9 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 			mockSessionRepo := mock_repository.NewMockSession(ctrl)
 			tt.prepareMockSessionRepoFn(mockSessionRepo)
 
-			s := NewSessionTimerUseCase(mockSessionRepo, mockPlayer, mockPusher)
+			syncCheckTimerManager := entity.NewSyncCheckTimerManager()
+
+			s := NewSessionTimerUseCase(mockSessionRepo, mockPlayer, mockPusher, syncCheckTimerManager)
 			gotTriggerAfterTrackEnd, gotNextTrack, err := s.handleTrackEnd(context.Background(), tt.sessionID)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("handleTrackEnd() error = %v, wantErr %v", err, tt.wantErr)

--- a/web/handler/session_state_test.go
+++ b/web/handler/session_state_test.go
@@ -861,7 +861,8 @@ func newSessionStateHandlerForTest(
 	prepareMockUserRepoFn(mockUserRepo)
 	mockSessionRepo := mock_repository.NewMockSession(ctrl)
 	prepareMockSessionRepoFn(mockSessionRepo)
-	timerUC := usecase.NewSessionTimerUseCase(mockSessionRepo, mockPlayer, mockPusher)
+	syncCheckTimerManager := entity.NewSyncCheckTimerManager()
+	timerUC := usecase.NewSessionTimerUseCase(mockSessionRepo, mockPlayer, mockPusher, syncCheckTimerManager)
 	uc := usecase.NewSessionUseCase(mockSessionRepo, mockUserRepo, mockPlayer, nil, nil, mockPusher, timerUC)
 	stateUC := usecase.NewSessionStateUseCase(mockSessionRepo, mockPlayer, mockPusher, timerUC)
 	return &SessionHandler{uc: uc, stateUC: stateUC}


### PR DESCRIPTION
## Related Issue
#119 

## What

- timerをhandletrackEndの頭で削除
- timerが存在しない時はsyncCheckOffsetの時間なのでcpiのチェックは飛ばすように変更

## Memo
テスト通ってえええええ