### PR TITLE
曲の切替時にINTERRUPTが送られてくる問題を修正

### DIFF
--- a/usecase/session_timer_test.go
+++ b/usecase/session_timer_test.go
@@ -459,6 +459,12 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 			mockSessionRepo := mock_repository.NewMockSession(ctrl)
 			tt.prepareMockSessionRepoFn(mockSessionRepo)
 
+			tmpWaitTimeBeforeHandleTrackEnd := waitTimeBeforeHandleTrackEnd
+			waitTimeBeforeHandleTrackEnd = 0
+			defer func() {
+				waitTimeBeforeHandleTrackEnd = tmpWaitTimeBeforeHandleTrackEnd
+			}()
+
 			syncCheckTimerManager := entity.NewSyncCheckTimerManager()
 
 			s := NewSessionTimerUseCase(mockSessionRepo, mockPlayer, mockPusher, syncCheckTimerManager)


### PR DESCRIPTION
## Related Issue

close #152 

## What

- 曲の再生が終わる前にタイマーを発火するようにして、Spotify側が次の曲に行く前にDeleteTimerが呼ばれるようにする。
- タイマーが消されることで、GetSession呼び出し時にINTERRUPTにならなくなる

## Memo
<!-- レビュワーに伝えたいことがあれば -->