### PR TITLE
repositoryでトランザクションを使えるようにする

### DIFF
--- a/database/session_test.go
+++ b/database/session_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -85,7 +86,7 @@ func TestSessionRepository_FindByID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &SessionRepository{dbMap: dbMap}
-			got, err := r.FindByID(tt.id)
+			got, err := r.FindByID(context.TODO(), tt.id)
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("SessionRepository.FindByID() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -165,7 +166,7 @@ func TestSessionRepository_StoreSession(t *testing.T) {
 			r := &SessionRepository{
 				dbMap: dbMap,
 			}
-			if err := r.StoreSession(tt.session); !errors.Is(err, tt.wantErr) {
+			if err := r.StoreSession(context.TODO(), tt.session); !errors.Is(err, tt.wantErr) {
 				t.Errorf("SessionRepository.StoreSessions() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -248,13 +249,13 @@ func TestSessionRepository_Update(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewSessionRepository(dbMap)
-			if err := r.Update(tt.session); (err != nil) != tt.wantErr {
+			if err := r.Update(context.TODO(), tt.session); (err != nil) != tt.wantErr {
 				t.Errorf("Update() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 
 			if !tt.wantErr {
-				got, err := r.FindByID(tt.session.ID)
+				got, err := r.FindByID(context.TODO(), tt.session.ID)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -340,7 +341,7 @@ func TestSessionRepository_StoreQueueTrack(t *testing.T) {
 			r := &SessionRepository{
 				dbMap: dbMap,
 			}
-			if err := r.StoreQueueTrack(tt.queueTrack); !errors.Is(err, tt.wantErr) {
+			if err := r.StoreQueueTrack(context.TODO(), tt.queueTrack); !errors.Is(err, tt.wantErr) {
 				t.Errorf("SessionRepository.StoreQueueTracks() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
@@ -553,7 +554,7 @@ func TestSessionRepository_FindCreatorTokenBySessionID(t *testing.T) {
 			r := &SessionRepository{
 				dbMap: dbMap,
 			}
-			token, creatorID, err := r.FindCreatorTokenBySessionID(tt.sessionID)
+			token, creatorID, err := r.FindCreatorTokenBySessionID(context.TODO(), tt.sessionID)
 
 			if !errors.Is(err, tt.wantErr) {
 				t.Errorf("SessionRepository.FindCreatorTokenBySessionID() error = %v, wantErr %v", err, tt.wantErr)
@@ -645,7 +646,7 @@ func TestSessionRepository_ArchiveSessionsForBatch(t *testing.T) {
 				return
 			}
 
-			session, err := r.FindByID(tt.session.ID)
+			session, err := r.FindByID(context.TODO(), tt.session.ID)
 			if err != nil {
 				t.Errorf("SessionRepository.ArchiveSessionsForBatch() error = %v", err)
 				return
@@ -713,7 +714,7 @@ func TestSessionRepository_UpdateWithExpiredAt(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := NewSessionRepository(dbMap)
-			if err := r.UpdateWithExpiredAt(tt.session, tt.newExpiredAt); (err != nil) != tt.wantErr {
+			if err := r.UpdateWithExpiredAt(context.TODO(), tt.session, tt.newExpiredAt); (err != nil) != tt.wantErr {
 				t.Errorf("UpdateWithExpiredAt() error = %v, wantErr %v", err, tt.wantErr)
 			}
 

--- a/database/transaction.go
+++ b/database/transaction.go
@@ -1,0 +1,22 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/go-gorp/gorp/v3"
+)
+
+var txKey = struct{}{}
+
+type TransactionDAO interface {
+	SelectOne(holder interface{}, query string, args ...interface{}) error
+	Insert(list ...interface{}) error
+	Update(list ...interface{}) (int64, error)
+	Exec(query string, args ...interface{}) (sql.Result, error)
+}
+
+func getTx(ctx context.Context) (TransactionDAO, bool) {
+	tx, ok := ctx.Value(&txKey).(*gorp.Transaction)
+	return tx, ok
+}

--- a/domain/mock_repository/session.go
+++ b/domain/mock_repository/session.go
@@ -5,6 +5,7 @@
 package mock_repository
 
 import (
+	context "context"
 	entity "github.com/camphor-/relaym-server/domain/entity"
 	gomock "github.com/golang/mock/gomock"
 	oauth2 "golang.org/x/oauth2"
@@ -36,80 +37,80 @@ func (m *MockSession) EXPECT() *MockSessionMockRecorder {
 }
 
 // FindByID mocks base method
-func (m *MockSession) FindByID(id string) (*entity.Session, error) {
+func (m *MockSession) FindByID(ctx context.Context, id string) (*entity.Session, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindByID", id)
+	ret := m.ctrl.Call(m, "FindByID", ctx, id)
 	ret0, _ := ret[0].(*entity.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindByID indicates an expected call of FindByID
-func (mr *MockSessionMockRecorder) FindByID(id interface{}) *gomock.Call {
+func (mr *MockSessionMockRecorder) FindByID(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockSession)(nil).FindByID), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockSession)(nil).FindByID), ctx, id)
 }
 
 // StoreSession mocks base method
-func (m *MockSession) StoreSession(arg0 *entity.Session) error {
+func (m *MockSession) StoreSession(arg0 context.Context, arg1 *entity.Session) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreSession", arg0)
+	ret := m.ctrl.Call(m, "StoreSession", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreSession indicates an expected call of StoreSession
-func (mr *MockSessionMockRecorder) StoreSession(arg0 interface{}) *gomock.Call {
+func (mr *MockSessionMockRecorder) StoreSession(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreSession", reflect.TypeOf((*MockSession)(nil).StoreSession), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreSession", reflect.TypeOf((*MockSession)(nil).StoreSession), arg0, arg1)
 }
 
 // Update mocks base method
-func (m *MockSession) Update(arg0 *entity.Session) error {
+func (m *MockSession) Update(arg0 context.Context, arg1 *entity.Session) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", arg0)
+	ret := m.ctrl.Call(m, "Update", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update
-func (mr *MockSessionMockRecorder) Update(arg0 interface{}) *gomock.Call {
+func (mr *MockSessionMockRecorder) Update(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSession)(nil).Update), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockSession)(nil).Update), arg0, arg1)
 }
 
 // UpdateWithExpiredAt mocks base method
-func (m *MockSession) UpdateWithExpiredAt(arg0 *entity.Session, arg1 time.Time) error {
+func (m *MockSession) UpdateWithExpiredAt(arg0 context.Context, arg1 *entity.Session, arg2 time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateWithExpiredAt", arg0, arg1)
+	ret := m.ctrl.Call(m, "UpdateWithExpiredAt", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateWithExpiredAt indicates an expected call of UpdateWithExpiredAt
-func (mr *MockSessionMockRecorder) UpdateWithExpiredAt(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockSessionMockRecorder) UpdateWithExpiredAt(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWithExpiredAt", reflect.TypeOf((*MockSession)(nil).UpdateWithExpiredAt), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWithExpiredAt", reflect.TypeOf((*MockSession)(nil).UpdateWithExpiredAt), arg0, arg1, arg2)
 }
 
 // StoreQueueTrack mocks base method
-func (m *MockSession) StoreQueueTrack(arg0 *entity.QueueTrackToStore) error {
+func (m *MockSession) StoreQueueTrack(arg0 context.Context, arg1 *entity.QueueTrackToStore) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StoreQueueTrack", arg0)
+	ret := m.ctrl.Call(m, "StoreQueueTrack", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StoreQueueTrack indicates an expected call of StoreQueueTrack
-func (mr *MockSessionMockRecorder) StoreQueueTrack(arg0 interface{}) *gomock.Call {
+func (mr *MockSessionMockRecorder) StoreQueueTrack(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreQueueTrack", reflect.TypeOf((*MockSession)(nil).StoreQueueTrack), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StoreQueueTrack", reflect.TypeOf((*MockSession)(nil).StoreQueueTrack), arg0, arg1)
 }
 
 // FindCreatorTokenBySessionID mocks base method
-func (m *MockSession) FindCreatorTokenBySessionID(arg0 string) (*oauth2.Token, string, error) {
+func (m *MockSession) FindCreatorTokenBySessionID(arg0 context.Context, arg1 string) (*oauth2.Token, string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindCreatorTokenBySessionID", arg0)
+	ret := m.ctrl.Call(m, "FindCreatorTokenBySessionID", arg0, arg1)
 	ret0, _ := ret[0].(*oauth2.Token)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(error)
@@ -117,9 +118,9 @@ func (m *MockSession) FindCreatorTokenBySessionID(arg0 string) (*oauth2.Token, s
 }
 
 // FindCreatorTokenBySessionID indicates an expected call of FindCreatorTokenBySessionID
-func (mr *MockSessionMockRecorder) FindCreatorTokenBySessionID(arg0 interface{}) *gomock.Call {
+func (mr *MockSessionMockRecorder) FindCreatorTokenBySessionID(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCreatorTokenBySessionID", reflect.TypeOf((*MockSession)(nil).FindCreatorTokenBySessionID), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindCreatorTokenBySessionID", reflect.TypeOf((*MockSession)(nil).FindCreatorTokenBySessionID), arg0, arg1)
 }
 
 // ArchiveSessionsForBatch mocks base method
@@ -134,4 +135,19 @@ func (m *MockSession) ArchiveSessionsForBatch() error {
 func (mr *MockSessionMockRecorder) ArchiveSessionsForBatch() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ArchiveSessionsForBatch", reflect.TypeOf((*MockSession)(nil).ArchiveSessionsForBatch))
+}
+
+// DoInTx mocks base method
+func (m *MockSession) DoInTx(ctx context.Context, f func(context.Context) (interface{}, error)) (interface{}, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DoInTx", ctx, f)
+	ret0, _ := ret[0].(interface{})
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DoInTx indicates an expected call of DoInTx
+func (mr *MockSessionMockRecorder) DoInTx(ctx, f interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DoInTx", reflect.TypeOf((*MockSession)(nil).DoInTx), ctx, f)
 }

--- a/domain/repository/session.go
+++ b/domain/repository/session.go
@@ -3,6 +3,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/camphor-/relaym-server/domain/entity"
@@ -11,11 +12,12 @@ import (
 
 // Session はsessionを管理するためのリポジトリです。
 type Session interface {
-	FindByID(id string) (*entity.Session, error)
-	StoreSession(*entity.Session) error
-	Update(*entity.Session) error
-	UpdateWithExpiredAt(*entity.Session, time.Time) error
-	StoreQueueTrack(*entity.QueueTrackToStore) error
-	FindCreatorTokenBySessionID(string) (*oauth2.Token, string, error)
+	FindByID(ctx context.Context, id string) (*entity.Session, error)
+	StoreSession(context.Context, *entity.Session) error
+	Update(context.Context, *entity.Session) error
+	UpdateWithExpiredAt(context.Context, *entity.Session, time.Time) error
+	StoreQueueTrack(context.Context, *entity.QueueTrackToStore) error
+	FindCreatorTokenBySessionID(context.Context, string) (*oauth2.Token, string, error)
 	ArchiveSessionsForBatch() error
+	DoInTx(ctx context.Context, f func(ctx context.Context) (interface{}, error)) (interface{}, error)
 }

--- a/go.sum
+++ b/go.sum
@@ -25,10 +25,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.4.1 h1:/exdXoGamhu5ONeUJH0deniYLWYvQwW66yvlfiiKTu0=
-github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.0 h1:/QaMHBdZ26BB3SSst0Iwl10Epc+xhTquomWX0oZEB6w=
-github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=

--- a/usecase/auth.go
+++ b/usecase/auth.go
@@ -141,7 +141,7 @@ func (u *AuthUseCase) RefreshAccessToken(userID string, token *oauth2.Token) (*o
 
 // GetTokenAndCreatorIDBySessionID は指定されたidからsessionの持つcreatorのtokenを返します
 func (u *AuthUseCase) GetTokenAndCreatorIDBySessionID(sessionID string) (*oauth2.Token, string, error) {
-	token, creatorID, err := u.sessionRepo.FindCreatorTokenBySessionID(sessionID)
+	token, creatorID, err := u.sessionRepo.FindCreatorTokenBySessionID(context.Background(), sessionID)
 	if err != nil {
 		return nil, "", fmt.Errorf("FindCreatorTokenBySessionID: sessionID=%s: %w", sessionID, err)
 	}

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -36,12 +36,12 @@ func NewSessionUseCase(sessionRepo repository.Session, userRepo repository.User,
 
 // EnqueueTrack はセッションのqueueにTrackを追加します。
 func (s *SessionUseCase) EnqueueTrack(ctx context.Context, sessionID string, trackURI string) error {
-	session, err := s.sessionRepo.FindByID(sessionID)
+	session, err := s.sessionRepo.FindByID(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("FindByID sessionID=%s: %w", sessionID, err)
 	}
 
-	err = s.sessionRepo.StoreQueueTrack(&entity.QueueTrackToStore{
+	err = s.sessionRepo.StoreQueueTrack(ctx, &entity.QueueTrackToStore{
 		URI:       trackURI,
 		SessionID: sessionID,
 	})
@@ -64,7 +64,7 @@ func (s *SessionUseCase) EnqueueTrack(ctx context.Context, sessionID string, tra
 }
 
 // CreateSession は与えられたセッション名のセッションを作成します。
-func (s *SessionUseCase) CreateSession(sessionName string, creatorID string, allowToControlByOthers bool) (*entity.SessionWithUser, error) {
+func (s *SessionUseCase) CreateSession(ctx context.Context, sessionName string, creatorID string, allowToControlByOthers bool) (*entity.SessionWithUser, error) {
 	creator, err := s.userRepo.FindByID(creatorID)
 	if err != nil {
 		return nil, fmt.Errorf("FindByID userID=%s: %w", creatorID, err)
@@ -75,7 +75,7 @@ func (s *SessionUseCase) CreateSession(sessionName string, creatorID string, all
 		return nil, fmt.Errorf("NewSession sessionName=%s: %w", sessionName, err)
 	}
 
-	err = s.sessionRepo.StoreSession(newSession)
+	err = s.sessionRepo.StoreSession(ctx, newSession)
 	if err != nil {
 		return nil, fmt.Errorf("StoreSession sessionName=%s: %w", sessionName, err)
 	}
@@ -84,7 +84,7 @@ func (s *SessionUseCase) CreateSession(sessionName string, creatorID string, all
 
 // CanConnectToPusher はイベントをクライアントにプッシュするためのコネクションを貼れるかどうかチェックします。
 func (s *SessionUseCase) CanConnectToPusher(ctx context.Context, sessionID string) error {
-	sess, err := s.sessionRepo.FindByID(sessionID)
+	sess, err := s.sessionRepo.FindByID(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("find session id=%s: %w", sessionID, err)
 	}
@@ -101,13 +101,13 @@ func (s *SessionUseCase) CanConnectToPusher(ctx context.Context, sessionID strin
 
 // SetDevice は指定されたidのセッションの作成者と再生する端末を紐付けて再生するデバイスを指定します。
 func (s *SessionUseCase) SetDevice(ctx context.Context, sessionID string, deviceID string) error {
-	sess, err := s.sessionRepo.FindByID(sessionID)
+	sess, err := s.sessionRepo.FindByID(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("find session id=%s: %w", sessionID, err)
 	}
 
 	sess.DeviceID = deviceID
-	if err := s.sessionRepo.Update(sess); err != nil {
+	if err := s.sessionRepo.Update(ctx, sess); err != nil {
 		return fmt.Errorf("update device id: device_id=%s session_id=%s: %w", deviceID, sess.ID, err)
 	}
 
@@ -116,7 +116,7 @@ func (s *SessionUseCase) SetDevice(ctx context.Context, sessionID string, device
 
 // GetSession は指定されたidからsessionの情報を返します
 func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*entity.SessionWithUser, []*entity.Track, *entity.CurrentPlayingInfo, error) {
-	session, err := s.sessionRepo.FindByID(sessionID)
+	session, err := s.sessionRepo.FindByID(ctx, sessionID)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("FindByID sessionID=%s: %w", sessionID, err)
 	}
@@ -147,7 +147,7 @@ func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*ent
 			s.timerUC.deleteTimer(session.ID)
 			s.timerUC.handleInterrupt(session)
 
-			if updateErr := s.sessionRepo.Update(session); updateErr != nil {
+			if updateErr := s.sessionRepo.Update(ctx, session); updateErr != nil {
 				return nil, nil, nil, fmt.Errorf("update session id=%s: %v: %w", session.ID, err, updateErr)
 			}
 

--- a/usecase/session_test.go
+++ b/usecase/session_test.go
@@ -22,7 +22,7 @@ func TestSessionUseCase_CanConnectToPusher(t *testing.T) {
 			name:      "存在しないセッションのとき404",
 			sessionID: "not_found_session_id",
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("not_found_session_id").Return(nil, entity.ErrSessionNotFound)
+				m.EXPECT().FindByID(gomock.Any(), "not_found_session_id").Return(nil, entity.ErrSessionNotFound)
 			},
 			wantErr: true,
 		},
@@ -30,7 +30,7 @@ func TestSessionUseCase_CanConnectToPusher(t *testing.T) {
 			name:      "StateがStopのセッションのとき正しくWebSocketのコネクションが確立される",
 			sessionID: "sessionID",
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:          "sessionID",
 					Name:        "session_name",
 					CreatorID:   "creator_id",
@@ -45,7 +45,7 @@ func TestSessionUseCase_CanConnectToPusher(t *testing.T) {
 			name:      "StateがPlayのセッションでタイマーが存在しないので、タイマーを作成した後、正しくWebSocketのコネクションが確立される",
 			sessionID: "sessionID",
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -84,13 +84,13 @@ func (s *SessionTimerUseCase) handleTrackEnd(ctx context.Context, sessionID stri
 	s.tm.DeleteTimer(sessionID)
 	time.Sleep(waitTimeBeforeHandleTrackEnd)
 
-	sess, err := s.sessionRepo.FindByID(sessionID)
+	sess, err := s.sessionRepo.FindByID(ctx, sessionID)
 	if err != nil {
 		return nil, false, fmt.Errorf("find session id=%s: %v", sessionID, err)
 	}
 
 	defer func() {
-		if err := s.sessionRepo.Update(sess); err != nil {
+		if err := s.sessionRepo.Update(ctx, sess); err != nil {
 			if returnErr != nil {
 				returnErr = fmt.Errorf("update session id=%s: %v: %w", sess.ID, err, returnErr)
 			} else {

--- a/usecase/session_timer_test.go
+++ b/usecase/session_timer_test.go
@@ -38,7 +38,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -50,7 +50,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 						{},
 					},
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -102,7 +102,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -122,7 +122,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -183,7 +183,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -213,7 +213,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -283,7 +283,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -303,7 +303,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -342,7 +342,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -362,7 +362,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -400,7 +400,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -420,7 +420,7 @@ func TestSessionTimerUseCase_handleTrackEnd(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",

--- a/web/handler/session.go
+++ b/web/handler/session.go
@@ -44,7 +44,7 @@ func (h *SessionHandler) PostSession(c echo.Context) error {
 
 	ctx := c.Request().Context()
 	userID, _ := service.GetUserIDFromContext(ctx)
-	session, err := h.uc.CreateSession(sessionName, userID, req.AllowToControlByOthers)
+	session, err := h.uc.CreateSession(ctx, sessionName, userID, req.AllowToControlByOthers)
 	if err != nil {
 		logger.Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError)

--- a/web/handler/session_state_test.go
+++ b/web/handler/session_state_test.go
@@ -50,7 +50,7 @@ func TestSessionHandler_State(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -82,7 +82,7 @@ func TestSessionHandler_State(t *testing.T) {
 				m.EXPECT().Push(&event.PushMessage{SessionID: "sessionID", Msg: entity.EventPlay})
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -95,7 +95,7 @@ func TestSessionHandler_State(t *testing.T) {
 					},
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -170,7 +170,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 				m.EXPECT().Push(&event.PushMessage{SessionID: "sessionID", Msg: entity.EventPlay})
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -183,7 +183,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 					},
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -210,7 +210,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -246,7 +246,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 				})
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -261,7 +261,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 					},
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -290,7 +290,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -314,7 +314,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -338,7 +338,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("notFoundSessionID").Return(nil, entity.ErrSessionNotFound)
+				m.EXPECT().FindByID(gomock.Any(), "notFoundSessionID").Return(nil, entity.ErrSessionNotFound)
 			},
 			wantErr:  true,
 			wantCode: http.StatusNotFound,
@@ -350,7 +350,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{StateType: entity.Archived}, nil)
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Archived}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -409,7 +409,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -419,7 +419,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 					QueueTracks:            nil,
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -445,7 +445,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -455,7 +455,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 					QueueTracks:            nil,
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -480,7 +480,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -490,7 +490,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 					QueueTracks:            nil,
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -515,7 +515,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -525,7 +525,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 					QueueTracks:            nil,
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -546,7 +546,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{StateType: entity.Stop}, nil)
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Stop}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -558,7 +558,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{StateType: entity.Archived}, nil)
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Archived}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -615,7 +615,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -628,7 +628,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 					},
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().UpdateWithExpiredAt(&entity.Session{
+				m.EXPECT().UpdateWithExpiredAt(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -652,7 +652,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{StateType: entity.Play}, nil)
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Play}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -664,7 +664,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{StateType: entity.Pause}, nil)
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Pause}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -676,7 +676,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{StateType: entity.Stop}, nil)
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Stop}, nil)
 			},
 			wantErr:  false,
 			wantCode: http.StatusAccepted,
@@ -735,7 +735,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -748,7 +748,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 					},
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -774,7 +774,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -787,7 +787,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 					},
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -813,7 +813,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -826,7 +826,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 					},
 					AllowToControlByOthers: true,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -850,7 +850,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -52,7 +52,7 @@ func TestSessionHandler_SetDevice(t *testing.T) {
 			sessionID: "session_id",
 			body:      `{"device_id": "device_id"}`,
 			prepareMockRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("session_id").Return(nil, entity.ErrSessionNotFound)
+				m.EXPECT().FindByID(gomock.Any(), "session_id").Return(nil, entity.ErrSessionNotFound)
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			wantErr:               true,
@@ -64,7 +64,7 @@ func TestSessionHandler_SetDevice(t *testing.T) {
 			sessionID: "session_id",
 			body:      `{"device_id": "device_id"}`,
 			prepareMockRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("session_id").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "session_id").Return(&entity.Session{
 					ID:          "session_id",
 					Name:        "name",
 					CreatorID:   "creator_id",
@@ -73,7 +73,7 @@ func TestSessionHandler_SetDevice(t *testing.T) {
 					QueueHead:   0,
 					QueueTracks: nil,
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:          "session_id",
 					Name:        "name",
 					CreatorID:   "creator_id",
@@ -169,7 +169,7 @@ func TestSessionHandler_PostSession(t *testing.T) {
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {},
 			prepareMockPusherFn: func(m *mock_event.MockPusher) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().StoreSession(gomock.Any()).Return(nil)
+				m.EXPECT().StoreSession(gomock.Any(), gomock.Any()).Return(nil)
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {
 				m.EXPECT().FindByID("creatorID").Return(user, nil)
@@ -297,8 +297,8 @@ func TestSessionHandler_Enqueue(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionHadManyTracksID").Return(sessionHadManyTracks, nil)
-				m.EXPECT().StoreQueueTrack(&entity.QueueTrackToStore{
+				m.EXPECT().FindByID(gomock.Any(), "sessionHadManyTracksID").Return(sessionHadManyTracks, nil)
+				m.EXPECT().StoreQueueTrack(gomock.Any(), &entity.QueueTrackToStore{
 					URI:       "spotify:track:valid_uri",
 					SessionID: "sessionHadManyTracksID",
 				}).Return(nil)
@@ -321,8 +321,8 @@ func TestSessionHandler_Enqueue(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(session, nil)
-				m.EXPECT().StoreQueueTrack(&entity.QueueTrackToStore{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(session, nil)
+				m.EXPECT().StoreQueueTrack(gomock.Any(), &entity.QueueTrackToStore{
 					URI:       "spotify:track:valid_uri",
 					SessionID: "sessionID",
 				}).Return(nil)
@@ -349,7 +349,7 @@ func TestSessionHandler_Enqueue(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("invalidSessionID").Return(nil, entity.ErrSessionNotFound)
+				m.EXPECT().FindByID(gomock.Any(), "invalidSessionID").Return(nil, entity.ErrSessionNotFound)
 			},
 			wantErr:  true,
 			wantCode: http.StatusNotFound,
@@ -526,7 +526,7 @@ func TestSessionHandler_GetSession(t *testing.T) {
 				m.EXPECT().FindByID("creatorID").Return(user, nil)
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("sessionID").Return(session, nil)
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(session, nil)
 			},
 			want:     sessionResponse,
 			wantErr:  false,
@@ -543,7 +543,7 @@ func TestSessionHandler_GetSession(t *testing.T) {
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("non_exist_sessionID").Return(nil, entity.ErrSessionNotFound)
+				m.EXPECT().FindByID(gomock.Any(), "non_exist_sessionID").Return(nil, entity.ErrSessionNotFound)
 			},
 			want:     nil,
 			wantErr:  true,
@@ -563,7 +563,7 @@ func TestSessionHandler_GetSession(t *testing.T) {
 				m.EXPECT().FindByID("creatorID").Return(user, nil)
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("play_sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "play_sessionID").Return(&entity.Session{
 					ID:        "play_sessionID",
 					Name:      "sessionName",
 					CreatorID: "creatorID",
@@ -642,7 +642,7 @@ func TestSessionHandler_GetSession(t *testing.T) {
 				m.EXPECT().FindByID("creatorID").Return(user, nil)
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID("play_sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "play_sessionID").Return(&entity.Session{
 					ID:        "play_sessionID",
 					Name:      "sessionName",
 					CreatorID: "creatorID",
@@ -657,7 +657,7 @@ func TestSessionHandler_GetSession(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Update(&entity.Session{
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
 					ID:        "play_sessionID",
 					Name:      "sessionName",
 					CreatorID: "creatorID",

--- a/web/sessionToken_middleware_test.go
+++ b/web/sessionToken_middleware_test.go
@@ -35,7 +35,7 @@ func TestSessionTokenMiddleware_SetTokenToContext(t *testing.T) {
 			name:      "DBからアクセストークンの取得に失敗すると500",
 			sessionID: "sessionID",
 			prepareSessionRepo: func(r *mock_repository.MockSession) {
-				r.EXPECT().FindCreatorTokenBySessionID("sessionID").Return(nil, "", errors.New("unknown error"))
+				r.EXPECT().FindCreatorTokenBySessionID(gomock.Any(), "sessionID").Return(nil, "", errors.New("unknown error"))
 			},
 			prepareAuthRepo: func(r *mock_repository.MockAuth) {},
 			prepareAuthCli:  func(c *mock_spotify.MockAuth) {},
@@ -57,7 +57,7 @@ func TestSessionTokenMiddleware_SetTokenToContext(t *testing.T) {
 			name:      "DBから取得したアクセストークンが正しくContextにセットされる",
 			sessionID: "sessionID",
 			prepareSessionRepo: func(r *mock_repository.MockSession) {
-				r.EXPECT().FindCreatorTokenBySessionID("sessionID").Return(&oauth2.Token{
+				r.EXPECT().FindCreatorTokenBySessionID(gomock.Any(), "sessionID").Return(&oauth2.Token{
 					AccessToken:  "access_token",
 					TokenType:    "Bearer",
 					RefreshToken: "refresh_token",
@@ -97,7 +97,7 @@ func TestSessionTokenMiddleware_SetTokenToContext(t *testing.T) {
 			name:      "アクセストークンの有効期限が切れているときに更新処理が走って正しく新しいトークンが保存される",
 			sessionID: "sessionID",
 			prepareSessionRepo: func(r *mock_repository.MockSession) {
-				r.EXPECT().FindCreatorTokenBySessionID("sessionID").Return(&oauth2.Token{
+				r.EXPECT().FindCreatorTokenBySessionID(gomock.Any(), "sessionID").Return(&oauth2.Token{
 					AccessToken:  "access_token",
 					TokenType:    "Bearer",
 					RefreshToken: "refresh_token",


### PR DESCRIPTION
## Related Issue

## What

- ctxにトランザクションの構造体が詰められているかどうかでトランザクションを使うか切り替えます。
- `DoInTx()` の `f` に渡された関数の中でRepositoryの関数を呼べば、勝手にトランザクションで処理を実行してくれます 

## Memo
<!-- レビュワーに伝えたいことがあれば -->
参考: https://qiita.com/miya-masa/items/316256924a1f0d7374bb