### PR TITLE
track APIのレスポンスをオンメモリでキャッシュする

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/labstack/echo/v4 v4.1.16
 	github.com/labstack/gommon v0.3.0
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/zmb3/spotify v0.0.0-20200422222148-5fe5f9535a2c
 	golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5 // indirect
 	golang.org/x/net v0.0.0-20200425230154-ff2c4b7c35a0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,8 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-sqlite3 v1.11.0 h1:LDdKkqtYlom37fkvqs8rMPFKAMe8+SgjbwZ6ex1/A/Q=
 github.com/mattn/go-sqlite3 v1.11.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
+github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/poy/onpar v0.0.0-20190519213022-ee068f8ea4d1 h1:oL4IBbcqwhhNWh31bjOX8C/OCy0zs9906d/VUru+bqg=

--- a/spotify/client.go
+++ b/spotify/client.go
@@ -2,23 +2,26 @@ package spotify
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/camphor-/relaym-server/config"
 
+	"github.com/patrickmn/go-cache"
 	"github.com/zmb3/spotify"
 	"golang.org/x/oauth2"
 )
 
 // Client はSpotifyのWeb APIをコールするクライアントです。
 type Client struct {
-	auth spotify.Authenticator
+	auth  spotify.Authenticator
+	cache *cache.Cache
 }
 
 // NewClient はClientのポインタを生成する関数です。
 func NewClient(cfg *config.Spotify) *Client {
 	auth := spotify.NewAuthenticator(cfg.RedirectURL(), spotify.ScopeUserReadPrivate, spotify.ScopeUserReadPlaybackState, spotify.ScopeUserModifyPlaybackState)
 	auth.SetAuthInfo(cfg.ClientID(), cfg.ClientSecret())
-	return &Client{auth: auth}
+	return &Client{auth: auth, cache: cache.New(5*time.Minute, 10*time.Minute)}
 }
 
 // GetAuthURL はSpotifyの認証画面のURLを取得します。

--- a/spotify/client.go
+++ b/spotify/client.go
@@ -21,7 +21,7 @@ type Client struct {
 func NewClient(cfg *config.Spotify) *Client {
 	auth := spotify.NewAuthenticator(cfg.RedirectURL(), spotify.ScopeUserReadPrivate, spotify.ScopeUserReadPlaybackState, spotify.ScopeUserModifyPlaybackState)
 	auth.SetAuthInfo(cfg.ClientID(), cfg.ClientSecret())
-	return &Client{auth: auth, cache: cache.New(5*time.Minute, 10*time.Minute)}
+	return &Client{auth: auth, cache: cache.New(10*time.Minute, 20*time.Minute)}
 }
 
 // GetAuthURL はSpotifyの認証画面のURLを取得します。

--- a/spotify/track.go
+++ b/spotify/track.go
@@ -1,6 +1,7 @@
 package spotify
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -14,21 +15,34 @@ import (
 
 // Search はSpotify APIを通して、与えられたクエリを用い音楽を検索します。
 func (c *Client) Search(ctx context.Context, q string) ([]*entity.Track, error) {
+	const searchKey = "searchKey"
+
 	token, ok := service.GetTokenFromContext(ctx)
 	if !ok {
 		return nil, fmt.Errorf("token not found")
 	}
 
-	cli := c.auth.NewClient(token)
-	result, err := cli.Search(q, spotify.SearchTypeTrack)
-	if err != nil {
-		return nil, fmt.Errorf("search q=%s: %w", q, err)
+	var result *spotify.SearchResult
+	cached, ok := c.cache.Get(searchKey + q)
+	if v, typeOK := cached.(*spotify.SearchResult); ok && typeOK {
+		result = v
+	} else {
+		var err error
+		cli := c.auth.NewClient(token)
+		result, err = cli.Search(q, spotify.SearchTypeTrack)
+		if err != nil {
+			return nil, fmt.Errorf("search q=%s: %w", q, err)
+		}
+		c.cache.SetDefault(searchKey+q, result)
 	}
-	return c.toTracks(result.Tracks.Tracks), nil
+	tracks := c.toTracks(result.Tracks.Tracks)
+
+	return tracks, nil
 }
 
 // GetTrackFromURI はSpotify APIを通して、与えられたTrack URIを用い音楽を取得します。
 func (c *Client) GetTracksFromURI(ctx context.Context, trackURIs []string) ([]*entity.Track, error) {
+	const getTracksKey = "getTracksKey"
 	if len(trackURIs) == 0 {
 		return nil, nil
 	}
@@ -55,11 +69,21 @@ func (c *Client) GetTracksFromURI(ctx context.Context, trackURIs []string) ([]*e
 		} else {
 			idsForAPI = ids[i*50 : (i+1)*50]
 		}
-		resultTracks, err := cli.GetTracks(idsForAPI...)
-		if err != nil {
-			return nil, fmt.Errorf("get track uris=%s: %w", trackURIs, err)
-		}
 
+		var resultTracks []*spotify.FullTrack
+		key := c.idsToCacheKey(idsForAPI)
+		cached, ok := c.cache.Get(getTracksKey + key)
+		if v, typeOK := cached.([]*spotify.FullTrack); ok && typeOK {
+			resultTracks = v
+
+		} else {
+			var err error
+			resultTracks, err = cli.GetTracks(idsForAPI...)
+			if err != nil {
+				return nil, fmt.Errorf("get track uris=%s: %w", trackURIs, err)
+			}
+			c.cache.SetDefault(getTracksKey+key, resultTracks)
+		}
 		for j, rt := range resultTracks {
 			idx := i*50 + j
 			tracks[idx] = c.toTrack(rt)
@@ -68,6 +92,14 @@ func (c *Client) GetTracksFromURI(ctx context.Context, trackURIs []string) ([]*e
 	}
 
 	return tracks, nil
+}
+
+func (c *Client) idsToCacheKey(ids []spotify.ID) string {
+	buff := bytes.Buffer{}
+	for _, id := range ids {
+		buff.WriteString(string(id))
+	}
+	return buff.String()
 }
 
 func (c *Client) toTracks(resultTracks []spotify.FullTrack) []*entity.Track {


### PR DESCRIPTION
## Related Issue

なし

## What

- レスポンスを速めるために、キャッシュできるAPIをキャッシュする


![スクリーンショット 2020-08-03 2 11 28](https://user-images.githubusercontent.com/30015728/89128207-ee36c480-d52e-11ea-845d-d5917d9c1ae1.png)
![スクリーンショット 2020-08-03 2 12 03](https://user-images.githubusercontent.com/30015728/89128208-ef67f180-d52e-11ea-97e4-93f84fafef6d.png)


## Memo
<!-- レビュワーに伝えたいことがあれば -->