### PR TITLE
同期チェックでPlayingが正しいかもかもチェックする

### DIFF
--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -130,6 +130,17 @@ func (s *Session) IsPlayingCorrectTrack(playingInfo *CurrentPlayingInfo) error {
 		})
 		return fmt.Errorf("session playing different track: queue track %s, but playing track %v: %w", s.QueueTracks[s.QueueHead].URI, playingInfo.Track, ErrSessionPlayingDifferentTrack)
 	}
+
+	if playingInfo.Playing != s.IsPlaying() {
+		logger.Infoj(map[string]interface{}{
+			"message":      "session playing, but spotify is not playing",
+			"queueTrack":   s.QueueTracks[s.QueueHead].URI,
+			"playingTrack": playingInfo.Track,
+		})
+		return fmt.Errorf("session playing, but spotify is not playing: %w", ErrSessionPlayingDifferentTrack)
+
+	}
+
 	return nil
 }
 

--- a/domain/entity/session_test.go
+++ b/domain/entity/session_test.go
@@ -478,6 +478,23 @@ func TestSession_IsPlayingCorrectTrack(t *testing.T) {
 			wantErr:     true,
 		},
 		{
+			name: "再生されているはずなのにSpotify側が一時停止していたらエラー",
+			session: &Session{
+				StateType: Play,
+				QueueHead: 0,
+				QueueTracks: []*QueueTrack{
+					{URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
+				},
+			},
+			playingInfo: &CurrentPlayingInfo{
+				Playing:  false,
+				Progress: 0,
+				Track:    &Track{},
+				Device:   &Device{},
+			},
+			wantErr: true,
+		},
+		{
 			name: "再生が終了してStopになっていたらエラーにならない",
 			session: &Session{
 				StateType: Stop,

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -212,6 +212,9 @@ func (s *SessionTimerUseCase) handleTrackEndTx(sessionID string) func(ctx contex
 
 		track := sess.TrackURIShouldBeAddedWhenHandleTrackEnd()
 		if track != "" {
+			// TODO: Spotifyアプリを閉じた後、ずっとRelaymを開かないとINTERRUPTにならずにここまでたどり着いて
+			// active device not foundになってしまう
+			// そのときstateはPLAYのままなので表示がバグる
 			if err := s.playerCli.Enqueue(ctx, track, sess.DeviceID); err != nil {
 				return &handleTrackEndResponse{
 					nextTrack: false,


### PR DESCRIPTION
## Related Issue

もしかしたら #184 

## What

- Spotifyが一時停止中だと、曲情報は入っているが Playingはfalseという状況になる。このとき、SessionのStateがPlayなら意図しない挙動なのでINTERRUPTになるようにする

## Memo
<!-- レビュワーに伝えたいことがあれば -->