### PR TITLE
他人への操作が許可されていないときはセッションをアーカイブしない

### DIFF
--- a/database/session.go
+++ b/database/session.go
@@ -162,7 +162,7 @@ func (r *SessionRepository) StoreQueueTrack(ctx context.Context, queueTrack *ent
 //// - 作成から3日以上が経過している。もしくはArchiveが解除されてから3日以上が経過している
 func (r *SessionRepository) ArchiveSessionsForBatch() error {
 	currentDateTime := time.Now().UTC()
-	if _, err := r.dbMap.Exec("UPDATE sessions SET state_type = 'ARCHIVED' WHERE state_type != 'ARCHIVED' AND expired_at < ?;", currentDateTime); err != nil {
+	if _, err := r.dbMap.Exec("UPDATE sessions SET state_type = 'ARCHIVED' WHERE allow_to_control_by_others = true AND state_type != 'ARCHIVED' AND expired_at < ?;", currentDateTime); err != nil {
 		return fmt.Errorf("update session state_type to ARCHIVED: %w", err)
 	}
 	return nil

--- a/database/session_test.go
+++ b/database/session_test.go
@@ -685,23 +685,36 @@ func TestSessionRepository_ArchiveSessionsForBatch(t *testing.T) {
 		DisplayName:   "existing_user_display_name",
 	}
 	oldSession := &sessionDTO{
-		ID:        "existing_session_id1",
-		Name:      "existing_session_name",
-		CreatorID: "existing_user",
-		QueueHead: 0,
-		StateType: "PLAY",
-		DeviceID:  "device_id",
-		ExpiredAt: time.Now().Add(-1 * 24 * time.Hour),
+		ID:                     "existing_session_id1",
+		Name:                   "existing_session_name",
+		CreatorID:              "existing_user",
+		QueueHead:              0,
+		StateType:              "PLAY",
+		DeviceID:               "device_id",
+		ExpiredAt:              time.Now().Add(-1 * 24 * time.Hour),
+		AllowToControlByOthers: true,
 	}
 
 	newSession := &sessionDTO{
-		ID:        "existing_session_id2",
-		Name:      "existing_session_name",
-		CreatorID: "existing_user",
-		QueueHead: 0,
-		StateType: "PLAY",
-		DeviceID:  "device_id",
-		ExpiredAt: time.Now().Add(1 * 24 * time.Hour),
+		ID:                     "existing_session_id2",
+		Name:                   "existing_session_name",
+		CreatorID:              "existing_user",
+		QueueHead:              0,
+		StateType:              "PLAY",
+		DeviceID:               "device_id",
+		ExpiredAt:              time.Now().Add(1 * 24 * time.Hour),
+		AllowToControlByOthers: true,
+	}
+
+	notAllowedSessions := &sessionDTO{
+		ID:                     "existing_session_id3",
+		Name:                   "existing_session_name",
+		CreatorID:              "existing_user",
+		QueueHead:              0,
+		StateType:              "PLAY",
+		DeviceID:               "device_id",
+		ExpiredAt:              time.Now().Add(-1 * 24 * time.Hour),
+		AllowToControlByOthers: false,
 	}
 
 	tests := []struct {
@@ -718,6 +731,11 @@ func TestSessionRepository_ArchiveSessionsForBatch(t *testing.T) {
 			name:      "古いsessionはARCHIVEされる",
 			session:   oldSession,
 			wantState: "ARCHIVED",
+		},
+		{
+			name:      "古くても他人の操作を許可していないsessionはARCHIVEされない",
+			session:   notAllowedSessions,
+			wantState: "PLAY",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Related Issue

close #183 

## What

- `AllowToControleByOthers` がtrueのもののみアーカイブするようにした 

## Memo
<!-- レビュワーに伝えたいことがあれば -->