### PR TITLE
Skipのデッドロックのバグを討伐

### DIFF
--- a/domain/entity/sync_check_timer.go
+++ b/domain/entity/sync_check_timer.go
@@ -116,7 +116,6 @@ func (m *SyncCheckTimerManager) DeleteTimer(sessionID string) {
 	}
 
 	logger.Debugj(map[string]interface{}{"message": "timer not existed", "sessionID": sessionID})
-	return
 }
 
 // GetTimer は与えられたセッションのタイマーを取得します。存在しない場合はfalseが返ります。

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -29,6 +29,9 @@ func NewSessionTimerUseCase(sessionRepo repository.Session, playerCli spotify.Pl
 
 // startTrackEndTrigger は曲の終了やストップを検知してそれぞれの処理を実行します。 goroutineで実行されることを想定しています。
 func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionID string) {
+	// startTrackEndTriggerが終了する際はTimerは必ず不要になるので削除
+	defer s.deleteTimer(sessionID)
+
 	logger := log.New()
 	logger.Debugj(map[string]interface{}{"message": "start track end trigger", "sessionID": sessionID})
 
@@ -46,7 +49,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 		case <-triggerAfterTrackEnd.StopCh():
 			logger.Infoj(map[string]interface{}{"message": "stop timer", "sessionID": sessionID})
 			waitTimer.Stop()
-			s.deleteTimer(sessionID)
 			return
 
 		case <-triggerAfterTrackEnd.NextCh():


### PR DESCRIPTION
## Related Issue
#190 

## What

- 送信まちが原因だったので送信待ちの発生を潰した
- そもそも送信待ちはchannelをcloseしてないことが原因だったのでstartTrackEndTriggerの終了時にはdeferで必ずchanellをclose（というかtimerをdelete）するようにした

## Memo
