### PR TITLE
大量にskipAPIが叩かれても同時に処理しないようにした

### DIFF
--- a/domain/entity/sync_check_timer.go
+++ b/domain/entity/sync_check_timer.go
@@ -116,7 +116,6 @@ func (m *SyncCheckTimerManager) DeleteTimer(sessionID string) {
 	}
 
 	logger.Debugj(map[string]interface{}{"message": "timer not existed", "sessionID": sessionID})
-	return
 }
 
 // GetTimer は与えられたセッションのタイマーを取得します。存在しない場合はfalseが返ります。

--- a/domain/entity/sync_check_timer.go
+++ b/domain/entity/sync_check_timer.go
@@ -197,22 +197,16 @@ func (m *SyncCheckTimerManager) SendToNextCh(sessionID string) {
 		}
 		logger.Debugj(map[string]interface{}{"message": "timer existed and NextCh disable", "sessionID": sessionID})
 		// isNextChEnableがfalseの時はskip処理の途中なので、再度isNextChEnableになるまで待つ
-		for {
-			select {
-			case _, ok := <-timer.enableNextCh:
-				if ok {
-					logger.Debugj(map[string]interface{}{"message": "timer NextCh be enable", "sessionID": sessionID})
-					m.mu.Lock()
-					timer.DisableNextCh()
-					timer.nextCh <- struct{}{}
-					m.mu.Unlock()
-					return
-				}
-				return
-			}
+		for range timer.enableNextCh {
+			logger.Debugj(map[string]interface{}{"message": "timer NextCh be enable", "sessionID": sessionID})
+			m.mu.Lock()
+			timer.DisableNextCh()
+			timer.nextCh <- struct{}{}
+			m.mu.Unlock()
+			return
 		}
+		return
 	}
-
 	logger.Debugj(map[string]interface{}{"message": "timer not existed on SendToNextCh", "sessionID": sessionID})
 }
 

--- a/domain/entity/sync_check_timer.go
+++ b/domain/entity/sync_check_timer.go
@@ -136,12 +136,11 @@ func (m *SyncCheckTimerManager) CreateExpiredTimer(sessionID string) *SyncCheckT
 
 	logger.Debugj(map[string]interface{}{"message": "create timer", "sessionID": sessionID})
 
-	if existing, ok := m.timers[sessionID]; ok {
+	if _, ok := m.timers[sessionID]; ok {
 		// 本来ならStopのGoDocコメントにある通り、<-t.Cとして、チャネルが空になっていることを確認すべきだが、
 		// ExpireCh()の呼び出し側で受け取っているので問題ない。
 		logger.Debugj(map[string]interface{}{"message": "timer has already exists", "sessionID": sessionID})
-		existing.timer.Stop()
-		close(existing.stopCh)
+		m.DeleteTimer(sessionID)
 	}
 	timer := newSyncCheckTimer()
 	m.timers[sessionID] = timer

--- a/domain/entity/sync_check_timer.go
+++ b/domain/entity/sync_check_timer.go
@@ -10,14 +10,11 @@ import (
 
 // SyncCheckTimer はSpotifyとの同期チェック用のタイマーです。タイマーが止まったことを確認するためのstopチャネルがあります。
 // ref : http://okzk.hatenablog.com/entry/2015/12/01/001924
-// nextChはisNextChEnableがtrueの時にのみ値を送ることを想定しています
 type SyncCheckTimer struct {
 	timer          *time.Timer
 	isTimerExpired bool
 	stopCh         chan struct{}
-	isNextChEnable bool
 	nextCh         chan struct{}
-	enableNextCh   chan struct{}
 }
 
 // ExpireCh は指定設定された秒数経過したことを送るチャネルを返します。
@@ -33,32 +30,6 @@ func (s *SyncCheckTimer) StopCh() <-chan struct{} {
 // NextCh は次の曲への遷移の指示を送るチャネルを返します。
 func (s *SyncCheckTimer) NextCh() <-chan struct{} {
 	return s.nextCh
-}
-
-// EnableNextCh はNextChを有効化します・
-// isNextChEnableをtrueにセットし、enableNextChに通知します
-func (s *SyncCheckTimer) EnableNextCh() {
-	select {
-	case s.enableNextCh <- struct{}{}:
-		s.isNextChEnable = true
-		return
-	default:
-		s.isNextChEnable = true
-		return
-	}
-}
-
-// DisableNextCh はNextChを無効化します。
-// isNextChEnableをfalseにセットし、enableNextChの中身を0にします
-func (s *SyncCheckTimer) DisableNextCh() {
-	select {
-	case <-s.enableNextCh:
-		s.isNextChEnable = false
-		return
-	default:
-		s.isNextChEnable = false
-		return
-	}
 }
 
 // MakeIsTimerExpiredTrue はisTimerExpiredをtrueに変更します
@@ -79,9 +50,7 @@ func newSyncCheckTimer() *SyncCheckTimer {
 	return &SyncCheckTimer{
 		stopCh:         make(chan struct{}, 2),
 		nextCh:         make(chan struct{}, 1),
-		enableNextCh:   make(chan struct{}, 1),
 		isTimerExpired: true,
-		isNextChEnable: true,
 		timer:          timer,
 	}
 }
@@ -161,36 +130,25 @@ func (m *SyncCheckTimerManager) GetTimer(sessionID string) (*SyncCheckTimer, boo
 }
 
 // SendToNextCh は与えられたセッションのタイマーのNextChに通知を送ります
-// 大量にskipが叩かれた場合の待ちが予想されるので、goroutineで実行されることを想定しています
-func (m *SyncCheckTimerManager) SendToNextCh(sessionID string) {
+func (m *SyncCheckTimerManager) SendToNextCh(sessionID string) error {
 	logger := log.New()
+	m.mu.Lock()
+	defer m.mu.Unlock()
 
 	logger.Debugj(map[string]interface{}{"message": "call next ch", "sessionID": sessionID})
 
 	if timer, ok := m.timers[sessionID]; ok {
-		if timer.isNextChEnable {
-			logger.Debugj(map[string]interface{}{"message": "timer existed and NextCh enable", "sessionID": sessionID})
-			m.mu.Lock()
-			timer.DisableNextCh()
-			timer.nextCh <- struct{}{}
-			m.mu.Unlock()
-			return
-		}
-		logger.Debugj(map[string]interface{}{"message": "timer existed and NextCh disable", "sessionID": sessionID})
-		// isNextChEnableがfalseの時はskip処理の途中なので、再度isNextChEnableになるまで待つ
-		for {
-			select {
-			case <-timer.enableNextCh:
-				m.mu.Lock()
-				timer.DisableNextCh()
-				timer.nextCh <- struct{}{}
-				m.mu.Unlock()
-				return
-			}
+		// skipを連打された時に送信ブロックが発生する可能性がある
+		select {
+		case timer.nextCh <- struct{}{}:
+			return nil
+		default:
+			return fmt.Errorf("timer existed, but channel's capacity is full")
 		}
 	}
 
 	logger.Debugj(map[string]interface{}{"message": "timer not existed on SendToNextCh", "sessionID": sessionID})
+	return fmt.Errorf("timer not existed")
 }
 
 // IsTimerExpired は与えられたセッションのisTimerExpiredの値を返します

--- a/domain/entity/sync_check_timer_test.go
+++ b/domain/entity/sync_check_timer_test.go
@@ -183,7 +183,7 @@ func TestSyncCheckTimerManager_GetTimer(t *testing.T) {
 			}
 			got, got1 := m.GetTimer(tt.sessionID)
 
-			opts := []cmp.Option{cmp.AllowUnexported(SyncCheckTimer{}), cmpopts.IgnoreUnexported(time.Timer{})}
+			opts := []cmp.Option{cmp.AllowUnexported(SyncCheckTimer{}), cmpopts.IgnoreUnexported(time.Timer{}, sync.Mutex{})}
 			if !cmp.Equal(got, tt.want, opts...) {
 				t.Errorf("GetTimer() diff=%v", cmp.Diff(tt.want, got, opts...))
 			}

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/camphor-/relaym-server/log"
+
 	"github.com/camphor-/relaym-server/domain/entity"
 	"github.com/camphor-/relaym-server/domain/event"
 	"github.com/camphor-/relaym-server/domain/repository"
@@ -116,6 +118,7 @@ func (s *SessionUseCase) SetDevice(ctx context.Context, sessionID string, device
 
 // GetSession は指定されたidからsessionの情報を返します
 func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*entity.SessionWithUser, []*entity.Track, *entity.CurrentPlayingInfo, error) {
+	logger := log.New()
 	session, err := s.sessionRepo.FindByIDForUpdate(ctx, sessionID)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("FindByID sessionID=%s: %w", sessionID, err)
@@ -156,6 +159,9 @@ func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*ent
 	}
 
 	if err := session.IsPlayingCorrectTrack(cpi); err != nil {
+		logger.Infoj(map[string]interface{}{
+			"message": "session should be playing but not playing from handleWaitTimerExpired",
+		})
 		s.timerUC.deleteTimer(session.ID)
 		s.timerUC.handleInterrupt(session)
 

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -160,7 +160,7 @@ func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*ent
 
 	if err := session.IsPlayingCorrectTrack(cpi); err != nil {
 		logger.Infoj(map[string]interface{}{
-			"message": "session should be playing but not playing from handleWaitTimerExpired",
+			"message": "IsPlayingCorrectTrack failed from getSession",
 		})
 		s.timerUC.deleteTimer(session.ID)
 		s.timerUC.handleInterrupt(session)

--- a/usecase/session.go
+++ b/usecase/session.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/camphor-/relaym-server/log"
-
 	"github.com/camphor-/relaym-server/domain/entity"
 	"github.com/camphor-/relaym-server/domain/event"
 	"github.com/camphor-/relaym-server/domain/repository"
@@ -118,7 +116,6 @@ func (s *SessionUseCase) SetDevice(ctx context.Context, sessionID string, device
 
 // GetSession は指定されたidからsessionの情報を返します
 func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*entity.SessionWithUser, []*entity.Track, *entity.CurrentPlayingInfo, error) {
-	logger := log.New()
 	session, err := s.sessionRepo.FindByIDForUpdate(ctx, sessionID)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("FindByID sessionID=%s: %w", sessionID, err)
@@ -159,11 +156,6 @@ func (s *SessionUseCase) GetSession(ctx context.Context, sessionID string) (*ent
 	}
 
 	if err := session.IsPlayingCorrectTrack(cpi); err != nil {
-		logger.Infoj(map[string]interface{}{
-			"message":   "session playing different track detect on get session",
-			"sessionID": sessionID,
-			"error":     err.Error(),
-		})
 		s.timerUC.deleteTimer(session.ID)
 		s.timerUC.handleInterrupt(session)
 

--- a/usecase/session_state.go
+++ b/usecase/session_state.go
@@ -40,7 +40,7 @@ func (s *SessionStateUseCase) NextTrack(ctx context.Context, sessionID string) e
 
 	switch session.StateType {
 	case entity.Play:
-		if err = s.nextTrackInPlay(ctx, session); err != nil {
+		if err = s.nextTrackInPlay(session); err != nil {
 			return fmt.Errorf("go next track in play session id=%s: %w", session.ID, err)
 		}
 	case entity.Pause:
@@ -59,15 +59,8 @@ func (s *SessionStateUseCase) NextTrack(ctx context.Context, sessionID string) e
 }
 
 // nextTrackInPlay はsessionのstateがPLAYの時のnextTrackの処理を行います
-func (s *SessionStateUseCase) nextTrackInPlay(ctx context.Context, session *entity.Session) error {
-	if err := s.playerCli.GoNextTrack(ctx, session.DeviceID); err != nil {
-		return fmt.Errorf("GoNextTrack: %w", err)
-	}
-
-	// NextChを通してstartTrackEndTriggerに次の曲への遷移を通知
-	if err := s.timerUC.sendToNextCh(session.ID); err != nil {
-		return fmt.Errorf("send to next ch: %w", err)
-	}
+func (s *SessionStateUseCase) nextTrackInPlay(session *entity.Session) error {
+	s.timerUC.sendToNextCh(session.ID)
 
 	return nil
 }

--- a/usecase/session_state.go
+++ b/usecase/session_state.go
@@ -40,7 +40,7 @@ func (s *SessionStateUseCase) NextTrack(ctx context.Context, sessionID string) e
 
 	switch session.StateType {
 	case entity.Play:
-		if err = s.nextTrackInPlay(session); err != nil {
+		if err = s.nextTrackInPlay(ctx, session); err != nil {
 			return fmt.Errorf("go next track in play session id=%s: %w", session.ID, err)
 		}
 	case entity.Pause:
@@ -59,8 +59,15 @@ func (s *SessionStateUseCase) NextTrack(ctx context.Context, sessionID string) e
 }
 
 // nextTrackInPlay はsessionのstateがPLAYの時のnextTrackの処理を行います
-func (s *SessionStateUseCase) nextTrackInPlay(session *entity.Session) error {
-	s.timerUC.sendToNextCh(session.ID)
+func (s *SessionStateUseCase) nextTrackInPlay(ctx context.Context, session *entity.Session) error {
+	if err := s.playerCli.GoNextTrack(ctx, session.DeviceID); err != nil {
+		return fmt.Errorf("GoNextTrack: %w", err)
+	}
+
+	// NextChを通してstartTrackEndTriggerに次の曲への遷移を通知
+	if err := s.timerUC.sendToNextCh(session.ID); err != nil {
+		return fmt.Errorf("send to next ch: %w", err)
+	}
 
 	return nil
 }

--- a/usecase/session_state.go
+++ b/usecase/session_state.go
@@ -28,7 +28,7 @@ func NewSessionStateUseCase(sessionRepo repository.Session, playerCli spotify.Pl
 
 // NextTrack は指定されたidのsessionを次の曲に進めます
 func (s *SessionStateUseCase) NextTrack(ctx context.Context, sessionID string) error {
-	session, err := s.sessionRepo.FindByID(ctx, sessionID)
+	session, err := s.sessionRepo.FindByIDForUpdate(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("find session id=%s: %w", sessionID, err)
 	}
@@ -131,7 +131,7 @@ func (s *SessionStateUseCase) nextTrackInStop(ctx context.Context, session *enti
 
 // ChangeSessionState は与えられたセッションのstateを操作します。
 func (s *SessionStateUseCase) ChangeSessionState(ctx context.Context, sessionID string, st entity.StateType) error {
-	session, err := s.sessionRepo.FindByID(ctx, sessionID)
+	session, err := s.sessionRepo.FindByIDForUpdate(ctx, sessionID)
 	if err != nil {
 		return fmt.Errorf("find session id=%s: %w", sessionID, err)
 	}

--- a/usecase/session_state.go
+++ b/usecase/session_state.go
@@ -40,7 +40,7 @@ func (s *SessionStateUseCase) NextTrack(ctx context.Context, sessionID string) e
 
 	switch session.StateType {
 	case entity.Play:
-		if err = s.nextTrackInPlay(ctx, session); err != nil {
+		if err = s.nextTrackInPlay(session); err != nil {
 			return fmt.Errorf("go next track in play session id=%s: %w", session.ID, err)
 		}
 	case entity.Pause:
@@ -59,16 +59,8 @@ func (s *SessionStateUseCase) NextTrack(ctx context.Context, sessionID string) e
 }
 
 // nextTrackInPlay はsessionのstateがPLAYの時のnextTrackの処理を行います
-func (s *SessionStateUseCase) nextTrackInPlay(ctx context.Context, session *entity.Session) error {
-	if err := s.playerCli.GoNextTrack(ctx, session.DeviceID); err != nil {
-		return fmt.Errorf("GoNextTrack: %w", err)
-	}
-
-	// NextChを通してstartTrackEndTriggerに次の曲への遷移を通知
-	if err := s.timerUC.sendToNextCh(session.ID); err != nil {
-		return fmt.Errorf("send to next ch: %w", err)
-	}
-
+func (s *SessionStateUseCase) nextTrackInPlay(session *entity.Session) error {
+	s.timerUC.sendToNextCh(session.ID)
 	return nil
 }
 

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -310,10 +310,12 @@ func (s *SessionTimerUseCase) handleInterrupt(sess *entity.Session) {
 }
 
 func (s *SessionTimerUseCase) setNewTimerOnWaitTimer(timer *time.Timer, d time.Duration) {
+	logger := log.New()
 	if !timer.Stop() {
 		select {
 		case <-timer.C:
 		default:
+			logger.Debugj(map[string]interface{}{"message": "timer has already stopped and popped from channel"})
 		}
 	}
 	timer.Reset(d)

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -69,7 +69,7 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 				return
 			}
 			if session.StateType != entity.Play {
-				logger.Errorj(map[string]interface{}{
+				logger.Infoj(map[string]interface{}{
 					"message":   "stateType must be play",
 					"sessionID": sessionID,
 					"stateType": session.StateType,

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -166,29 +166,19 @@ func (s *SessionTimerUseCase) handleWaitTimerExpiredTx(sessionID string, trigger
 				"message": "IsPlayingCorrectTrack failed from handleWaitTimerExpired",
 			})
 			s.handleInterrupt(sess)
-			if err := s.sessionRepo.Update(ctx, sess); err != nil {
-				logger.Errorj(map[string]interface{}{
-					"message":   "handleWaitTimerExpired: failed to update session after IsPlayingCorrectTrack and handleInterrupt",
-					"sessionID": sessionID,
-					"error":     err.Error(),
-				})
-				return nil, fmt.Errorf("failed to update session")
-			}
 			return nil, fmt.Errorf("session interrupt")
 		}
 
 		track := sess.TrackURIShouldBeAddedWhenHandleTrackEnd()
 		if track != "" {
 			if err := s.playerCli.Enqueue(ctx, track, sess.DeviceID); err != nil {
+				logger.Errorj(map[string]interface{}{
+					"message":   "handleWaitTimerExpired: failed to enqueue tracks",
+					"sessionID": sessionID,
+					"error":     err.Error(),
+				})
 				s.handleInterrupt(sess)
-				if err := s.sessionRepo.Update(ctx, sess); err != nil {
-					logger.Errorj(map[string]interface{}{
-						"message":   "handleWaitTimerExpired: failed to update session after Enqueue and handleInterrupt",
-						"sessionID": sessionID,
-						"error":     err.Error(),
-					})
-					return nil, fmt.Errorf("failed to enqueue track")
-				}
+				return nil, fmt.Errorf("failed to enqueue tracks")
 			}
 		}
 

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -55,7 +55,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 			logger.Debugj(map[string]interface{}{"message": "call to move next track", "sessionID": sessionID})
 			waitTimer.Stop()
 			triggerAfterTrackEnd.MakeIsTimerExpiredTrue()
-
 			session, err := s.sessionRepo.FindByIDForUpdate(ctx, sessionID)
 			if err != nil {
 				logger.Errorj(map[string]interface{}{
@@ -73,7 +72,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 				})
 				return
 			}
-
 			nextTrack, err := s.handleTrackEnd(ctx, sessionID)
 			if err != nil {
 				if errors.Is(err, entity.ErrSessionPlayingDifferentTrack) {
@@ -87,7 +85,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 				logger.Infoj(map[string]interface{}{"message": "no next track", "sessionID": sessionID})
 				return
 			}
-
 			s.setNewTimerOnWaitTimer(waitTimer, waitTimeAfterHandleSkipTrack)
 			currentOperation = operationNextTrack
 

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -29,6 +29,9 @@ func NewSessionTimerUseCase(sessionRepo repository.Session, playerCli spotify.Pl
 
 // startTrackEndTrigger は曲の終了やストップを検知してそれぞれの処理を実行します。 goroutineで実行されることを想定しています。
 func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionID string) {
+	// startTrackEndTriggerが終了する際はTimerは必ず不要になるので削除
+	defer s.deleteTimer(sessionID)
+
 	logger := log.New()
 	logger.Debugj(map[string]interface{}{"message": "start track end trigger", "sessionID": sessionID})
 
@@ -46,7 +49,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 		case <-triggerAfterTrackEnd.StopCh():
 			logger.Infoj(map[string]interface{}{"message": "stop timer", "sessionID": sessionID})
 			waitTimer.Stop()
-			s.deleteTimer(sessionID)
 			return
 
 		case <-triggerAfterTrackEnd.NextCh():

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -74,10 +74,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 			}
 			nextTrack, err := s.handleTrackEnd(ctx, sessionID)
 			if err != nil {
-				if errors.Is(err, entity.ErrSessionPlayingDifferentTrack) {
-					logger.Infoj(map[string]interface{}{"message": "handleTrackEnd detects interrupt", "sessionID": sessionID, "error": err.Error()})
-					return
-				}
 				logger.Errorj(map[string]interface{}{"message": "handleTrackEnd with error", "sessionID": sessionID, "error": err.Error()})
 				return
 			}
@@ -93,10 +89,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 			logger.Debugj(map[string]interface{}{"message": "trigger expired", "sessionID": sessionID})
 			nextTrack, err := s.handleTrackEnd(ctx, sessionID)
 			if err != nil {
-				if errors.Is(err, entity.ErrSessionPlayingDifferentTrack) {
-					logger.Infoj(map[string]interface{}{"message": "handleTrackEnd detects interrupt", "sessionID": sessionID, "error": err.Error()})
-					return
-				}
 				logger.Errorj(map[string]interface{}{"message": "handleTrackEnd with error", "sessionID": sessionID, "error": err.Error()})
 				return
 			}

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -75,10 +75,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 			}
 			nextTrack, err := s.handleTrackEnd(ctx, sessionID)
 			if err != nil {
-				if errors.Is(err, entity.ErrSessionPlayingDifferentTrack) {
-					logger.Infoj(map[string]interface{}{"message": "handleTrackEnd detects interrupt", "sessionID": sessionID, "error": err.Error()})
-					return
-				}
 				logger.Errorj(map[string]interface{}{"message": "handleTrackEnd with error", "sessionID": sessionID, "error": err.Error()})
 				return
 			}
@@ -95,10 +91,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 			logger.Debugj(map[string]interface{}{"message": "trigger expired", "sessionID": sessionID})
 			nextTrack, err := s.handleTrackEnd(ctx, sessionID)
 			if err != nil {
-				if errors.Is(err, entity.ErrSessionPlayingDifferentTrack) {
-					logger.Infoj(map[string]interface{}{"message": "handleTrackEnd detects interrupt", "sessionID": sessionID, "error": err.Error()})
-					return
-				}
 				logger.Errorj(map[string]interface{}{"message": "handleTrackEnd with error", "sessionID": sessionID, "error": err.Error()})
 				return
 			}

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -126,7 +126,7 @@ func (s *SessionTimerUseCase) handleWaitTimerExpired(ctx context.Context, sessio
 		return fmt.Errorf("failed to get currently playing info")
 	}
 
-	sess, err := s.sessionRepo.FindByIDForUpdate(ctx, sessionID)
+	sess, err := s.sessionRepo.FindByID(ctx, sessionID)
 	if err != nil {
 		logger.Errorj(map[string]interface{}{
 			"message":   "handleWaitTimerExpired: failed to get session",

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -54,7 +54,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 					s.setNewTimerOnWaitTimer(waitTimer, waitTimeAfterHandleSkipTrack)
 					isRetryOnce = true
 				} else {
-					isRetryOnce = false
 					return
 				}
 			} else {

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -87,7 +87,7 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 				return
 			}
 
-			waitTimer = time.NewTimer(waitTimeAfterHandleSkipTrack)
+			s.setNewTimerOnWaitTimer(waitTimer, waitTimeAfterHandleSkipTrack)
 			currentOperation = operationNextTrack
 
 		case <-triggerAfterTrackEnd.ExpireCh():
@@ -106,7 +106,7 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 				logger.Infoj(map[string]interface{}{"message": "no next track", "sessionID": sessionID})
 				return
 			}
-			waitTimer = time.NewTimer(waitTimeAfterHandleTrackEnd)
+			s.setNewTimerOnWaitTimer(waitTimer, waitTimeAfterHandleTrackEnd)
 			currentOperation = operationNextTrack
 		}
 	}
@@ -273,6 +273,16 @@ func (s *SessionTimerUseCase) handleInterrupt(sess *entity.Session) {
 		SessionID: sess.ID,
 		Msg:       entity.EventInterrupt,
 	})
+}
+
+func (s *SessionTimerUseCase) setNewTimerOnWaitTimer(timer *time.Timer, d time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(d)
 }
 
 func (s *SessionTimerUseCase) existsTimer(sessionID string) bool {

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -160,7 +160,7 @@ func (s *SessionTimerUseCase) handleWaitTimerExpiredTx(sessionID string, trigger
 				}
 			}
 
-			if manager.currentOperation == operationNextTrack {
+			if manager.currentOperation == operationNextTrack || manager.currentOperation == operationRetryNextTrack {
 				triggerAfterTrackEnd.UnlockNextCh()
 			}
 		}()

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -54,26 +54,6 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 		case <-triggerAfterTrackEnd.NextCh():
 			logger.Debugj(map[string]interface{}{"message": "call to move next track", "sessionID": sessionID})
 			waitTimer.Stop()
-			triggerAfterTrackEnd.MakeIsTimerExpiredTrue()
-
-			session, err := s.sessionRepo.FindByIDForUpdate(ctx, sessionID)
-			if err != nil {
-				logger.Errorj(map[string]interface{}{
-					"message":   "failed to get session",
-					"sessionID": sessionID,
-					"error":     err.Error(),
-				})
-				return
-			}
-			if err := s.playerCli.GoNextTrack(ctx, session.DeviceID); err != nil {
-				logger.Errorj(map[string]interface{}{
-					"message":   "failed to go next track",
-					"sessionID": sessionID,
-					"error":     err.Error(),
-				})
-				return
-			}
-
 			nextTrack, err := s.handleTrackEnd(ctx, sessionID)
 			if err != nil {
 				if errors.Is(err, entity.ErrSessionPlayingDifferentTrack) {
@@ -127,7 +107,7 @@ func (s *SessionTimerUseCase) handleWaitTimerExpired(ctx context.Context, sessio
 		return fmt.Errorf("failed to get currently playing info")
 	}
 
-	sess, err := s.sessionRepo.FindByIDForUpdate(ctx, sessionID)
+	sess, err := s.sessionRepo.FindByID(ctx, sessionID)
 	if err != nil {
 		logger.Errorj(map[string]interface{}{
 			"message":   "handleWaitTimerExpired: failed to get session",
@@ -171,7 +151,6 @@ func (s *SessionTimerUseCase) handleWaitTimerExpired(ctx context.Context, sessio
 			SessionID: sess.ID,
 			Msg:       entity.NewEventNextTrack(sess.QueueHead),
 		})
-		triggerAfterTrackEnd.EnableNextCh()
 	}
 
 	// ぴったしのタイマーをセットすると、Spotifyでは次の曲の再生が始まってるのにRelaym側では次の曲に進んでおらず、
@@ -289,8 +268,8 @@ func (s *SessionTimerUseCase) isTimerExpired(sessionID string) (bool, error) {
 	return s.tm.IsTimerExpired(sessionID)
 }
 
-func (s *SessionTimerUseCase) sendToNextCh(sessionID string) {
-	go s.tm.SendToNextCh(sessionID)
+func (s *SessionTimerUseCase) sendToNextCh(sessionID string) error {
+	return s.tm.SendToNextCh(sessionID)
 }
 
 type handleTrackEndResponse struct {

--- a/usecase/session_timer_test.go
+++ b/usecase/session_timer_test.go
@@ -362,7 +362,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -416,7 +416,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -471,7 +471,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -527,7 +527,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",

--- a/usecase/session_timer_test.go
+++ b/usecase/session_timer_test.go
@@ -320,7 +320,7 @@ func TestSessionTimerUseCase_handleTrackEndTx(t *testing.T) {
 	}
 }
 
-func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
+func TestSessionTimerUseCase_handleWaitTimerExpiredTx(t *testing.T) {
 	tests := []struct {
 		name                     string
 		sessionID                string
@@ -362,7 +362,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -377,6 +377,21 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 					AllowToControlByOthers: false,
 					ProgressWhenPaused:     0,
 				}, nil)
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
+					ID:        "sessionID",
+					Name:      "name",
+					CreatorID: "creatorID",
+					DeviceID:  "deviceID",
+					StateType: "PLAY",
+					QueueHead: 1,
+					QueueTracks: []*entity.QueueTrack{
+						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
+						{Index: 1, URI: "spotify:track:06QTSGUEgcmKwiEJ0IMPig"},
+					},
+					ExpiredAt:              time.Time{},
+					AllowToControlByOthers: false,
+					ProgressWhenPaused:     0,
+				}).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -416,7 +431,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -431,6 +446,21 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 					AllowToControlByOthers: false,
 					ProgressWhenPaused:     0,
 				}, nil)
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
+					ID:        "sessionID",
+					Name:      "name",
+					CreatorID: "creatorID",
+					DeviceID:  "deviceID",
+					StateType: "PLAY",
+					QueueHead: 1,
+					QueueTracks: []*entity.QueueTrack{
+						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
+						{Index: 1, URI: "spotify:track:06QTSGUEgcmKwiEJ0IMPig"},
+					},
+					ExpiredAt:              time.Time{},
+					AllowToControlByOthers: false,
+					ProgressWhenPaused:     0,
+				}).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -471,7 +501,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -488,6 +518,23 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 					AllowToControlByOthers: false,
 					ProgressWhenPaused:     0,
 				}, nil)
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
+					ID:        "sessionID",
+					Name:      "name",
+					CreatorID: "creatorID",
+					DeviceID:  "deviceID",
+					StateType: "PLAY",
+					QueueHead: 1,
+					QueueTracks: []*entity.QueueTrack{
+						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
+						{Index: 1, URI: "spotify:track:06QTSGUEgcmKwiEJ0IMPig"},
+						{Index: 2, URI: "spotify:track:track2"},
+						{Index: 3, URI: "spotify:track:track3"},
+					},
+					ExpiredAt:              time.Time{},
+					AllowToControlByOthers: false,
+					ProgressWhenPaused:     0,
+				}).Return(nil)
 			},
 			wantErr: false,
 		},
@@ -527,7 +574,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -589,7 +636,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 				triggerAfterTrackEnd.LockNextCh()
 			}
 
-			if err := s.handleWaitTimerExpired(context.Background(), tt.sessionID, triggerAfterTrackEnd, tt.currentOperation); (err != nil) != tt.wantErr {
+			if _, err := s.handleWaitTimerExpiredTx(tt.sessionID, triggerAfterTrackEnd, tt.currentOperation)(context.Background()); (err != nil) != tt.wantErr {
 				t.Errorf("handleWaitTimerExpired() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/usecase/session_timer_test.go
+++ b/usecase/session_timer_test.go
@@ -362,7 +362,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -416,7 +416,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -471,7 +471,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",
@@ -527,7 +527,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "name",
 					CreatorID: "creatorID",

--- a/usecase/session_timer_test.go
+++ b/usecase/session_timer_test.go
@@ -585,6 +585,9 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			s := NewSessionTimerUseCase(mockSessionRepo, mockPlayer, mockPusher, syncCheckTimerManager)
 
 			triggerAfterTrackEnd := s.tm.CreateExpiredTimer(tt.sessionID)
+			if tt.currentOperation == operationNextTrack {
+				triggerAfterTrackEnd.LockNextCh()
+			}
 
 			if err := s.handleWaitTimerExpired(context.Background(), tt.sessionID, triggerAfterTrackEnd, tt.currentOperation); (err != nil) != tt.wantErr {
 				t.Errorf("handleWaitTimerExpired() error = %v, wantErr %v", err, tt.wantErr)

--- a/usecase/session_timer_test.go
+++ b/usecase/session_timer_test.go
@@ -539,7 +539,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpiredTx(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:             "NextTrackの時にSpotifyとの同期が取れていないとoperationRetryに変更され、エラーは返さない",
+			name:             "NextTrackの時にSpotifyとの同期が取れていないとoperationRetryNextTrackに変更され、エラーは返さない",
 			sessionID:        "sessionID",
 			currentOperation: "NextTrack",
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
@@ -605,7 +605,7 @@ func TestSessionTimerUseCase_handleWaitTimerExpiredTx(t *testing.T) {
 		{
 			name:             "Retryの時にSpotifyとの同期が取れていないとエラーが返り、handleInterruptが飛ぶ",
 			sessionID:        "sessionID",
-			currentOperation: "Retry",
+			currentOperation: "RetryNextTrack",
 			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
 				m.EXPECT().CurrentlyPlaying(gomock.Any()).Return(&entity.CurrentPlayingInfo{
 					Playing:  true,

--- a/web/handler/session_state_test.go
+++ b/web/handler/session_state_test.go
@@ -54,7 +54,7 @@ func TestSessionHandler_State(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -86,7 +86,7 @@ func TestSessionHandler_State(t *testing.T) {
 				m.EXPECT().Push(&event.PushMessage{SessionID: "sessionID", Msg: entity.EventPlay})
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -176,7 +176,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 				m.EXPECT().Push(&event.PushMessage{SessionID: "sessionID", Msg: entity.EventPlay})
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -218,7 +218,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -254,7 +254,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 				})
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -298,7 +298,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -322,7 +322,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -346,7 +346,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "notFoundSessionID").Return(nil, entity.ErrSessionNotFound)
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "notFoundSessionID").Return(nil, entity.ErrSessionNotFound)
 			},
 			wantErr:  true,
 			wantCode: http.StatusNotFound,
@@ -358,7 +358,7 @@ func TestSessionHandler_State_PLAY(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Archived}, nil)
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Archived}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -420,7 +420,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -461,7 +461,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -501,7 +501,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -541,7 +541,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:                     "sessionID",
 					Name:                   "session_name",
 					CreatorID:              "creator_id",
@@ -574,7 +574,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Stop}, nil)
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Stop}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -586,7 +586,7 @@ func TestSessionHandler_State_PAUSE(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Archived}, nil)
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Archived}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -644,7 +644,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -698,7 +698,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Pause, CreatorID: "creator_id"}, nil)
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Pause, CreatorID: "creator_id"}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -711,7 +711,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Play, CreatorID: "creator_id"}, nil)
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Play, CreatorID: "creator_id"}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -724,7 +724,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Pause, CreatorID: "creator_id"}, nil)
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Pause, CreatorID: "creator_id"}, nil)
 			},
 			wantErr:  true,
 			wantCode: http.StatusBadRequest,
@@ -737,7 +737,7 @@ func TestSessionHandler_State_STOP(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Stop, CreatorID: "creator_id"}, nil)
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{StateType: entity.Stop, CreatorID: "creator_id"}, nil)
 			},
 			wantErr:  false,
 			wantCode: http.StatusAccepted,
@@ -797,7 +797,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -837,7 +837,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -877,7 +877,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 			},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -915,7 +915,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",
@@ -940,7 +940,7 @@ func TestSessionHandler_State_ARCHIVED(t *testing.T) {
 			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
 			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(&entity.Session{
 					ID:        "sessionID",
 					Name:      "session_name",
 					CreatorID: "creator_id",

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -981,6 +981,7 @@ func TestUserHandler_NextTrack(t *testing.T) {
 			userID:              "userID",
 			addToTimerSessionID: "sessionID",
 			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {
+				m.EXPECT().GoNextTrack(gomock.Any(), "deviceID").Return(nil)
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -976,13 +976,11 @@ func TestUserHandler_NextTrack(t *testing.T) {
 			wantCode:              http.StatusBadRequest,
 		},
 		{
-			name:                "Playかつ次の曲が存在する時に次の曲にPlayのまま遷移,202",
-			sessionID:           "sessionID",
-			userID:              "userID",
-			addToTimerSessionID: "sessionID",
-			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {
-				m.EXPECT().GoNextTrack(gomock.Any(), "deviceID").Return(nil)
-			},
+			name:                   "Playかつ次の曲が存在する時に次の曲にPlayのまま遷移,202",
+			sessionID:              "sessionID",
+			userID:                 "userID",
+			addToTimerSessionID:    "sessionID",
+			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(
 					&entity.Session{

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -851,7 +851,7 @@ func TestUserHandler_NextTrack(t *testing.T) {
 			addToTimerSessionID:    "sessionID",
 			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
 					&entity.Session{
 						ID:        "sessionID",
 						Name:      "name",
@@ -917,7 +917,7 @@ func TestUserHandler_NextTrack(t *testing.T) {
 			addToTimerSessionID:    "sessionID",
 			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
 					&entity.Session{
 						ID:        "sessionID",
 						Name:      "name",
@@ -955,7 +955,7 @@ func TestUserHandler_NextTrack(t *testing.T) {
 			addToTimerSessionID:    "sessionID",
 			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
 					&entity.Session{
 						ID:                     "sessionID",
 						Name:                   "name",
@@ -982,7 +982,7 @@ func TestUserHandler_NextTrack(t *testing.T) {
 			addToTimerSessionID:    "sessionID",
 			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
 					&entity.Session{
 						ID:                     "sessionID",
 						Name:                   "name",
@@ -1009,7 +1009,7 @@ func TestUserHandler_NextTrack(t *testing.T) {
 			addToTimerSessionID:    "sessionID",
 			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
 					&entity.Session{
 						ID:                     "sessionID",
 						Name:                   "name",
@@ -1039,7 +1039,7 @@ func TestUserHandler_NextTrack(t *testing.T) {
 				m.EXPECT().Pause(gomock.Any(), "deviceID").Return(nil)
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
 					&entity.Session{
 						ID:        "sessionID",
 						Name:      "name",
@@ -1109,7 +1109,7 @@ func TestUserHandler_NextTrack(t *testing.T) {
 				m.EXPECT().Enqueue(gomock.Any(), "spotify:track:track_uri4", "deviceID").Return(nil)
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
 					&entity.Session{
 						ID:        "sessionID",
 						Name:      "name",

--- a/web/handler/session_test.go
+++ b/web/handler/session_test.go
@@ -981,7 +981,6 @@ func TestUserHandler_NextTrack(t *testing.T) {
 			userID:              "userID",
 			addToTimerSessionID: "sessionID",
 			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {
-				m.EXPECT().GoNextTrack(gomock.Any(), "deviceID").Return(nil)
 			},
 			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
 				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(


### PR DESCRIPTION
## Related Issue
#192 #190 

## What

- spotifyAPIのSkipは反映まで少しかかるがそれまでに叩かれた分のskipが一気に反映される
- そのためskipAPIが連打されると一気に数曲分Spotifyでは進むが、relaymでは一曲しか進まない的な現象が起こった
- relaym側でskipAPIが一曲ずつ反映されるように処理をためるように変更した
- これによってNextChを通して一度通知がいくと、NextChへの通知はいったん堰き止められ、handleWaitTimerExpiredの最後でNextChへ通知が再度通るようにする
- これにより、何度skipを連続で叩かれても、400msごとに一つずつ丁寧にskipが処理される、はず

## Memo
- 時々連打するとdifferent trackが走る時がある、おそらくSpotifyAPIのSkipの反映までの時間がまちまちでかっっなり遅い時に当たるとdifferent trackになる気がしてる、けど400ms以上遅くしてもSkipがさらにもっさりしてしまうので妥協ラインな気がしている、
というか結構な連打をしてる想定時なのでユーザーもこれでInterrupt出ても怒らんやろ！お前が連打するから悪いんだぞそもそも！！
（とか言ってSpotifyAPiのせいにしてるけどこっちのミスだったら一生SpotifyAPIの方角に足を向けて寝ません）

（追記）
- different trackの際にもう400msまつことにした、それでもdifferent trackならInterrupt送る

## TODO
- [x] skipの処理を色々行ってる時にpauseにしようとするなどの別の処理をした時の影響の確認