### PR TITLE
大量にskipAPIが叩かれても同時に処理しないようにした (トランザクションとレートリミットを使ってみたパターン)

### DIFF
--- a/domain/entity/session.go
+++ b/domain/entity/session.go
@@ -99,7 +99,7 @@ func (s *Session) IsCreator(userID string) bool {
 func (s *Session) GoNextTrack() error {
 	s.SetProgressWhenPaused(0 * time.Second)
 	if len(s.QueueTracks) <= s.QueueHead+1 {
-		s.QueueHead++ // https://github.com/camphor-/relaym-server/blob/master/docs/definition.md#%E7%8F%BE%E5%9C%A8%E5%AF%BE%E8%B1%A1%E3%81%AE%E6%9B%B2%E3%81%AE%E3%82%A4%E3%83%B3%E3%83%87%E3%83%83%E3%82%AF%E3%82%B9-head
+		s.QueueHead = len(s.QueueTracks) // https://github.com/camphor-/relaym-server/blob/master/docs/definition.md#%E7%8F%BE%E5%9C%A8%E5%AF%BE%E8%B1%A1%E3%81%AE%E6%9B%B2%E3%81%AE%E3%82%A4%E3%83%B3%E3%83%87%E3%83%83%E3%82%AF%E3%82%B9-head
 		s.StateType = Stop
 		return ErrSessionAllTracksFinished
 	}

--- a/usecase/session_state_test.go
+++ b/usecase/session_state_test.go
@@ -1,0 +1,381 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/camphor-/relaym-server/domain/service"
+
+	"github.com/camphor-/relaym-server/domain/entity"
+	"github.com/camphor-/relaym-server/domain/event"
+	"github.com/camphor-/relaym-server/domain/mock_event"
+	"github.com/camphor-/relaym-server/domain/mock_repository"
+	"github.com/camphor-/relaym-server/domain/mock_spotify"
+	"github.com/golang/mock/gomock"
+)
+
+func TestSessionStateUseCase_nextTrackInPauseTx(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                     string
+		sessionID                string
+		userID                   string
+		addToTimerSessionID      string
+		prepareMockPlayerCliFn   func(m *mock_spotify.MockPlayer)
+		prepareMockSessionRepoFn func(m *mock_repository.MockSession)
+		prepareMockPusherFn      func(m *mock_event.MockPusher)
+		prepareMockTrackCliFn    func(m *mock_spotify.MockTrackClient)
+		prepareMockUserRepoFn    func(m *mock_repository.MockUser)
+		wantErr                  bool
+	}{
+		{
+			name:                "Pauseかつ次の曲が存在すると次の曲に遷移し、202",
+			sessionID:           "sessionID",
+			userID:              "userID",
+			addToTimerSessionID: "sessionID",
+			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {
+				m.EXPECT().GoNextTrack(gomock.Any(), "deviceID").Return(nil)
+				m.EXPECT().Pause(gomock.Any(), "deviceID").Return(nil)
+			},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
+					&entity.Session{
+						ID:        "sessionID",
+						Name:      "name",
+						CreatorID: "creatorID",
+						DeviceID:  "deviceID",
+						StateType: "PAUSE",
+						QueueHead: 0,
+						QueueTracks: []*entity.QueueTrack{
+							{
+								Index:     0,
+								URI:       "spotify:track:track_uri1",
+								SessionID: "sessionID",
+							},
+							{
+								Index:     1,
+								URI:       "spotify:track:track_uri2",
+								SessionID: "sessionID",
+							},
+						},
+						ExpiredAt:              time.Time{},
+						AllowToControlByOthers: true,
+						ProgressWhenPaused:     0,
+					}, nil)
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
+					ID:        "sessionID",
+					Name:      "name",
+					CreatorID: "creatorID",
+					DeviceID:  "deviceID",
+					StateType: "PAUSE",
+					QueueHead: 1,
+					QueueTracks: []*entity.QueueTrack{
+						{
+							Index:     0,
+							URI:       "spotify:track:track_uri1",
+							SessionID: "sessionID",
+						},
+						{
+							Index:     1,
+							URI:       "spotify:track:track_uri2",
+							SessionID: "sessionID",
+						},
+					},
+					ExpiredAt:              time.Time{},
+					AllowToControlByOthers: true,
+					ProgressWhenPaused:     0,
+				})
+			},
+			prepareMockPusherFn: func(m *mock_event.MockPusher) {
+				m.EXPECT().Push(&event.PushMessage{
+					SessionID: "sessionID",
+					Msg:       entity.NewEventNextTrack(1),
+				})
+			},
+			prepareMockTrackCliFn: func(m *mock_spotify.MockTrackClient) {},
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			wantErr:               false,
+		},
+		{
+			name:                "Pauseかつ次の曲が3曲存在すると次の曲に遷移し、三曲先がEnqueueされ、202",
+			sessionID:           "sessionID",
+			userID:              "userID",
+			addToTimerSessionID: "sessionID",
+			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {
+				m.EXPECT().GoNextTrack(gomock.Any(), "deviceID").Return(nil)
+				m.EXPECT().Pause(gomock.Any(), "deviceID").Return(nil)
+				m.EXPECT().Enqueue(gomock.Any(), "spotify:track:track_uri4", "deviceID").Return(nil)
+			},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
+					&entity.Session{
+						ID:        "sessionID",
+						Name:      "name",
+						CreatorID: "creatorID",
+						DeviceID:  "deviceID",
+						StateType: "PAUSE",
+						QueueHead: 0,
+						QueueTracks: []*entity.QueueTrack{
+							{
+								Index:     0,
+								URI:       "spotify:track:track_uri1",
+								SessionID: "sessionID",
+							},
+							{
+								Index:     1,
+								URI:       "spotify:track:track_uri2",
+								SessionID: "sessionID",
+							},
+							{
+								Index:     2,
+								URI:       "spotify:track:track_uri3",
+								SessionID: "sessionID",
+							},
+							{
+								Index:     3,
+								URI:       "spotify:track:track_uri4",
+								SessionID: "sessionID",
+							},
+						},
+						ExpiredAt:              time.Time{},
+						AllowToControlByOthers: true,
+						ProgressWhenPaused:     0,
+					}, nil)
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
+					ID:        "sessionID",
+					Name:      "name",
+					CreatorID: "creatorID",
+					DeviceID:  "deviceID",
+					StateType: "PAUSE",
+					QueueHead: 1,
+					QueueTracks: []*entity.QueueTrack{
+						{
+							Index:     0,
+							URI:       "spotify:track:track_uri1",
+							SessionID: "sessionID",
+						},
+						{
+							Index:     1,
+							URI:       "spotify:track:track_uri2",
+							SessionID: "sessionID",
+						},
+						{
+							Index:     2,
+							URI:       "spotify:track:track_uri3",
+							SessionID: "sessionID",
+						},
+						{
+							Index:     3,
+							URI:       "spotify:track:track_uri4",
+							SessionID: "sessionID",
+						},
+					},
+					ExpiredAt:              time.Time{},
+					AllowToControlByOthers: true,
+					ProgressWhenPaused:     0,
+				})
+			},
+			prepareMockPusherFn: func(m *mock_event.MockPusher) {
+				m.EXPECT().Push(&event.PushMessage{
+					SessionID: "sessionID",
+					Msg:       entity.NewEventNextTrack(1),
+				})
+			},
+			prepareMockTrackCliFn: func(m *mock_spotify.MockTrackClient) {},
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			wantErr:               false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// モックの準備
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			uc := newSessionStateUseCaseForTest(t, ctrl, tt.prepareMockPlayerCliFn, tt.prepareMockTrackCliFn,
+				tt.prepareMockPusherFn, tt.prepareMockUserRepoFn, tt.prepareMockSessionRepoFn, tt.addToTimerSessionID)
+
+			ctx := context.Background()
+			ctx = service.SetUserIDToContext(ctx, tt.userID)
+
+			_, err := uc.nextTrackInPauseTx(tt.sessionID)(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NextTrack() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSessionStateUseCase_nextTrackInStopTx(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                     string
+		sessionID                string
+		userID                   string
+		addToTimerSessionID      string
+		prepareMockPlayerCliFn   func(m *mock_spotify.MockPlayer)
+		prepareMockSessionRepoFn func(m *mock_repository.MockSession)
+		prepareMockPusherFn      func(m *mock_event.MockPusher)
+		prepareMockTrackCliFn    func(m *mock_spotify.MockTrackClient)
+		prepareMockUserRepoFn    func(m *mock_repository.MockUser)
+		wantErr                  bool
+	}{
+		{
+			name:                   "STOPかつ次の曲が存在する時に次の曲にSTOPのまま遷移,202",
+			sessionID:              "sessionID",
+			userID:                 "userID",
+			addToTimerSessionID:    "sessionID",
+			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
+					&entity.Session{
+						ID:        "sessionID",
+						Name:      "name",
+						CreatorID: "creatorID",
+						DeviceID:  "deviceID",
+						StateType: "STOP",
+						QueueHead: 0,
+						QueueTracks: []*entity.QueueTrack{
+							{
+								Index:     0,
+								URI:       "spotify:track:track_uri1",
+								SessionID: "sessionID",
+							},
+							{
+								Index:     1,
+								URI:       "spotify:track:track_uri2",
+								SessionID: "sessionID",
+							},
+						},
+						ExpiredAt:              time.Time{},
+						AllowToControlByOthers: true,
+						ProgressWhenPaused:     0,
+					}, nil)
+				m.EXPECT().Update(gomock.Any(), &entity.Session{
+					ID:        "sessionID",
+					Name:      "name",
+					CreatorID: "creatorID",
+					DeviceID:  "deviceID",
+					StateType: "STOP",
+					QueueHead: 1,
+					QueueTracks: []*entity.QueueTrack{
+						{
+							Index:     0,
+							URI:       "spotify:track:track_uri1",
+							SessionID: "sessionID",
+						},
+						{
+							Index:     1,
+							URI:       "spotify:track:track_uri2",
+							SessionID: "sessionID",
+						},
+					},
+					ExpiredAt:              time.Time{},
+					AllowToControlByOthers: true,
+					ProgressWhenPaused:     0,
+				}).Return(nil)
+			},
+			prepareMockPusherFn: func(m *mock_event.MockPusher) {
+				m.EXPECT().Push(&event.PushMessage{
+					SessionID: "sessionID",
+					Msg:       entity.NewEventNextTrack(1),
+				})
+			},
+			prepareMockTrackCliFn: func(m *mock_spotify.MockTrackClient) {},
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			wantErr:               false,
+		},
+		{
+			name:                   "STOPかつ次の曲が存在しない時にErrNextQueueTrackNotFound,400",
+			sessionID:              "sessionID",
+			userID:                 "userID",
+			addToTimerSessionID:    "sessionID",
+			prepareMockPlayerCliFn: func(m *mock_spotify.MockPlayer) {},
+			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
+				m.EXPECT().FindByIDForUpdate(gomock.Any(), "sessionID").Return(
+					&entity.Session{
+						ID:        "sessionID",
+						Name:      "name",
+						CreatorID: "creatorID",
+						DeviceID:  "deviceID",
+						StateType: "STOP",
+						QueueHead: 2,
+						QueueTracks: []*entity.QueueTrack{
+							{
+								Index:     0,
+								URI:       "spotify:track:track_uri1",
+								SessionID: "sessionID",
+							},
+							{
+								Index:     1,
+								URI:       "spotify:track:track_uri2",
+								SessionID: "sessionID",
+							},
+						},
+						ExpiredAt:              time.Time{},
+						AllowToControlByOthers: true,
+						ProgressWhenPaused:     0,
+					}, nil)
+			},
+			prepareMockPusherFn:   func(m *mock_event.MockPusher) {},
+			prepareMockTrackCliFn: func(m *mock_spotify.MockTrackClient) {},
+			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
+			wantErr:               true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// モックの準備
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			uc := newSessionStateUseCaseForTest(t, ctrl, tt.prepareMockPlayerCliFn, tt.prepareMockTrackCliFn,
+				tt.prepareMockPusherFn, tt.prepareMockUserRepoFn, tt.prepareMockSessionRepoFn, tt.addToTimerSessionID)
+
+			ctx := context.Background()
+			ctx = service.SetUserIDToContext(ctx, tt.userID)
+
+			_, err := uc.nextTrackInStopTx(tt.sessionID)(ctx)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("NextTrack() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// モックの準備
+func newSessionStateUseCaseForTest(
+	t *testing.T,
+	ctrl *gomock.Controller,
+	prepareMockPlayerFn func(m *mock_spotify.MockPlayer),
+	prepareMockTrackFun func(m *mock_spotify.MockTrackClient),
+	prepareMockPusherFn func(m *mock_event.MockPusher),
+	prepareMockUserRepoFn func(m *mock_repository.MockUser),
+	prepareMockSessionRepoFn func(m *mock_repository.MockSession),
+	sessionID string) *SessionStateUseCase {
+	t.Helper()
+
+	mockPlayer := mock_spotify.NewMockPlayer(ctrl)
+	prepareMockPlayerFn(mockPlayer)
+	mockTrackCli := mock_spotify.NewMockTrackClient(ctrl)
+	prepareMockTrackFun(mockTrackCli)
+	mockPusher := mock_event.NewMockPusher(ctrl)
+	prepareMockPusherFn(mockPusher)
+	mockUserRepo := mock_repository.NewMockUser(ctrl)
+	prepareMockUserRepoFn(mockUserRepo)
+	mockSessionRepo := mock_repository.NewMockSession(ctrl)
+	prepareMockSessionRepoFn(mockSessionRepo)
+	syncCheckTimerManager := entity.NewSyncCheckTimerManager()
+	if sessionID != "" {
+		timer := syncCheckTimerManager.CreateExpiredTimer(sessionID)
+		timer.SetDuration(5 * time.Minute)
+	}
+	timerUC := NewSessionTimerUseCase(mockSessionRepo, mockPlayer, mockPusher, syncCheckTimerManager)
+	return NewSessionStateUseCase(mockSessionRepo, mockPlayer, mockPusher, timerUC)
+
+}

--- a/usecase/session_timer.go
+++ b/usecase/session_timer.go
@@ -52,7 +52,7 @@ func (s *SessionTimerUseCase) startTrackEndTrigger(ctx context.Context, sessionI
 		case <-triggerAfterTrackEnd.NextCh():
 			logger.Debugj(map[string]interface{}{"message": "call to move next track", "sessionID": sessionID})
 			waitTimer.Stop()
-			nextTrack, err := s.handleTrackEnd(ctx, sessionID)
+			nextTrack, err := s.handleNext(ctx, sessionID)
 			if err != nil {
 				if errors.Is(err, entity.ErrSessionPlayingDifferentTrack) {
 					logger.Infoj(map[string]interface{}{"message": "handleTrackEnd detects interrupt", "sessionID": sessionID, "error": err.Error()})
@@ -128,21 +128,6 @@ func (s *SessionTimerUseCase) handleWaitTimerExpired(ctx context.Context, sessio
 		return fmt.Errorf("session interrupt")
 	}
 
-	track := sess.TrackURIShouldBeAddedWhenHandleTrackEnd()
-	if track != "" {
-		if err := s.playerCli.Enqueue(ctx, track, sess.DeviceID); err != nil {
-			s.handleInterrupt(sess)
-			if err := s.sessionRepo.Update(ctx, sess); err != nil {
-				logger.Errorj(map[string]interface{}{
-					"message":   "handleWaitTimerExpired: failed to update session after Enqueue and handleInterrupt",
-					"sessionID": sessionID,
-					"error":     err.Error(),
-				})
-				return fmt.Errorf("failed to enqueue track")
-			}
-		}
-	}
-
 	switch currentOperation {
 	case operationNextTrack:
 		s.pusher.Push(&event.PushMessage{
@@ -168,6 +153,23 @@ func (s *SessionTimerUseCase) handleWaitTimerExpired(ctx context.Context, sessio
 func (s *SessionTimerUseCase) handleTrackEnd(ctx context.Context, sessionID string) (bool, error) {
 
 	triggerAfterTrackEndResponse, err := s.sessionRepo.DoInTx(ctx, s.handleTrackEndTx(sessionID))
+	if v, ok := triggerAfterTrackEndResponse.(*handleTrackEndResponse); ok {
+		// これはトランザクションが失敗してRollbackしたとき
+		if err != nil {
+			return false, fmt.Errorf("handle track end in transaction: %w", err)
+		}
+		return v.nextTrack, v.err
+	}
+	// これはトランザクションが失敗してRollbackしたとき
+	if err != nil {
+		return false, fmt.Errorf("handle track end in transaction: %w", err)
+	}
+	return false, nil
+}
+
+// handleTrackEnd はある一曲の再生が終わったときの処理を行います。
+func (s *SessionTimerUseCase) handleNext(ctx context.Context, sessionID string) (bool, error) {
+	triggerAfterTrackEndResponse, err := s.sessionRepo.DoInTx(ctx, s.handleNextTx(sessionID))
 	if v, ok := triggerAfterTrackEndResponse.(*handleTrackEndResponse); ok {
 		// これはトランザクションが失敗してRollbackしたとき
 		if err != nil {
@@ -222,6 +224,90 @@ func (s *SessionTimerUseCase) handleTrackEndTx(sessionID string) func(ctx contex
 				nextTrack: false,
 				err:       nil,
 			}, nil
+		}
+
+		track := sess.TrackURIShouldBeAddedWhenHandleTrackEnd()
+		if track != "" {
+			if err := s.playerCli.Enqueue(ctx, track, sess.DeviceID); err != nil {
+				s.handleInterrupt(sess)
+				if err := s.sessionRepo.Update(ctx, sess); err != nil {
+					logger.Errorj(map[string]interface{}{
+						"message":   "handleWaitTimerExpired: failed to update session after Enqueue and handleInterrupt",
+						"sessionID": sessionID,
+						"error":     err.Error(),
+					})
+					return &handleTrackEndResponse{err: err}, fmt.Errorf("failed to enqueue track")
+				}
+				return &handleTrackEndResponse{nextTrack: false, err: nil}, nil
+			}
+		}
+
+		logger.Debugj(map[string]interface{}{"message": "next track", "sessionID": sess.ID, "queueHead": sess.QueueHead})
+
+		return &handleTrackEndResponse{nextTrack: true, err: nil}, nil
+	}
+}
+
+// handleTrackEndTx はINTERRUPTになってerrorを帰す場合もトランザクションをコミットして欲しいので、
+// アプリケーションエラーはhandleTrackEndResponseのフィールドで返すようにしてerrorの返り値はnilにしている
+func (s *SessionTimerUseCase) handleNextTx(sessionID string) func(ctx context.Context) (interface{}, error) {
+	logger := log.New()
+	return func(ctx context.Context) (_ interface{}, returnErr error) {
+		sess, err := s.sessionRepo.FindByIDForUpdate(ctx, sessionID)
+		if err != nil {
+			return &handleTrackEndResponse{nextTrack: false}, fmt.Errorf("find session id=%s: %v", sessionID, err)
+		}
+
+		defer func() {
+			if err := s.sessionRepo.Update(ctx, sess); err != nil {
+				if returnErr != nil {
+					returnErr = fmt.Errorf("update session id=%s: %v: %w", sess.ID, err, returnErr)
+				} else {
+					returnErr = fmt.Errorf("update session id=%s: %w", sess.ID, err)
+				}
+			}
+		}()
+
+		if err := s.playerCli.GoNextTrack(ctx, sess.DeviceID); err != nil {
+			return &handleTrackEndResponse{nextTrack: false}, fmt.Errorf("GoNextTrack: %w", err)
+		}
+
+		// 曲の再生中にArchivedになった場合
+		if sess.StateType == entity.Archived {
+
+			s.pusher.Push(&event.PushMessage{
+				SessionID: sess.ID,
+				Msg:       entity.EventArchived,
+			})
+
+			return &handleTrackEndResponse{
+				nextTrack: false,
+				err:       nil,
+			}, nil
+		}
+
+		if err := sess.GoNextTrack(); err != nil && errors.Is(err, entity.ErrSessionAllTracksFinished) {
+			s.handleAllTrackFinish(sess)
+			return &handleTrackEndResponse{
+				nextTrack: false,
+				err:       nil,
+			}, nil
+		}
+
+		track := sess.TrackURIShouldBeAddedWhenHandleTrackEnd()
+		if track != "" {
+			if err := s.playerCli.Enqueue(ctx, track, sess.DeviceID); err != nil {
+				s.handleInterrupt(sess)
+				if err := s.sessionRepo.Update(ctx, sess); err != nil {
+					logger.Errorj(map[string]interface{}{
+						"message":   "handleWaitTimerExpired: failed to update session after Enqueue and handleInterrupt",
+						"sessionID": sessionID,
+						"error":     err.Error(),
+					})
+					return &handleTrackEndResponse{err: err}, fmt.Errorf("failed to enqueue track")
+				}
+				return &handleTrackEndResponse{nextTrack: false, err: nil}, nil
+			}
 		}
 
 		logger.Debugj(map[string]interface{}{"message": "next track", "sessionID": sess.ID, "queueHead": sess.QueueHead})

--- a/usecase/session_timer_test.go
+++ b/usecase/session_timer_test.go
@@ -435,63 +435,6 @@ func TestSessionTimerUseCase_handleWaitTimerExpired(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:             "Spotifyとの同期が取れていることが確認されると、新しく追加すべき曲がSpotifyのキューに追加される",
-			sessionID:        "sessionID",
-			currentOperation: "NextTrack",
-			prepareMockPlayerFn: func(m *mock_spotify.MockPlayer) {
-				m.EXPECT().CurrentlyPlaying(gomock.Any()).Return(&entity.CurrentPlayingInfo{
-					Playing:  true,
-					Progress: 10000000,
-					Track: &entity.Track{
-						URI:      "spotify:track:06QTSGUEgcmKwiEJ0IMPig",
-						ID:       "06QTSGUEgcmKwiEJ0IMPig",
-						Name:     "Borderland",
-						Duration: 213066000000,
-						Artists:  []*entity.Artist{{Name: "MONOEYES"}},
-						URL:      "https://open.spotify.com/track/06QTSGUEgcmKwiEJ0IMPig",
-						Album: &entity.Album{
-							Name: "Interstate 46 E.P.",
-							Images: []*entity.AlbumImage{
-								{
-									URL:    "https://i.scdn.co/image/ab67616d0000b273b48630d6efcebca2596120c4",
-									Height: 640,
-									Width:  640,
-								},
-							},
-						},
-					},
-				}, nil)
-				m.EXPECT().Enqueue(gomock.Any(), "spotify:track:track3", "deviceID").Return(nil)
-			},
-			prepareMockPusherFn: func(m *mock_event.MockPusher) {
-				m.EXPECT().Push(&event.PushMessage{
-					SessionID: "sessionID",
-					Msg:       entity.NewEventNextTrack(1),
-				})
-			},
-			prepareMockUserRepoFn: func(m *mock_repository.MockUser) {},
-			prepareMockSessionRepoFn: func(m *mock_repository.MockSession) {
-				m.EXPECT().FindByID(gomock.Any(), "sessionID").Return(&entity.Session{
-					ID:        "sessionID",
-					Name:      "name",
-					CreatorID: "creatorID",
-					DeviceID:  "deviceID",
-					StateType: "PLAY",
-					QueueHead: 1,
-					QueueTracks: []*entity.QueueTrack{
-						{Index: 0, URI: "spotify:track:5uQ0vKy2973Y9IUCd1wMEF"},
-						{Index: 1, URI: "spotify:track:06QTSGUEgcmKwiEJ0IMPig"},
-						{Index: 2, URI: "spotify:track:track2"},
-						{Index: 3, URI: "spotify:track:track3"},
-					},
-					ExpiredAt:              time.Time{},
-					AllowToControlByOthers: false,
-					ProgressWhenPaused:     0,
-				}, nil)
-			},
-			wantErr: false,
-		},
-		{
 			name:             "Spotifyとの同期が取れていないとhandleInterruptが呼び出されErrorが返る",
 			sessionID:        "sessionID",
 			currentOperation: "NextTrack",


### PR DESCRIPTION
## Related Issue

#192 #190

## What

#193 のコメントで書いた
> これDBのトランザクションを使えばもっとスマートに解決できる気がしてきた

https://github.com/camphor-/relaym-server/pull/193#issuecomment-671187287

を上手く説明できる気がしなかったのでPR作ってみました

- StateがPAUSE、STOPのときは処理をDBのトランザクションで囲むことで、APIコールごとに直列で処理を行うことで、タイミングによって、動作がおかしくなるといったことはなくなる。
- `sendToNextTrackNotToExceedCap()` でチャネルのキャパシティ以上呼び出されても、チャネルにメッセージを送らず破棄するようにする。これでPLAY時にAPIを超絶大量に投げられても、デッドロックすることはなくなり、スキップをちゃんとされる。
  - そもそも連打を全て律儀にスキップする必要はない（それは考えうる動作でないので）という発想からの実装
- `DoInTx` で囲むとハンドラーレイヤーからテストを書きづらいので、正常系のテスト(DoInTxの中を確かめる必要があるテスト）はユースケース側に持ってきた

## Memo
<!-- レビュワーに伝えたいことがあれば -->